### PR TITLE
Fix/union near miss

### DIFF
--- a/ClippingBezier.xcodeproj/project.pbxproj
+++ b/ClippingBezier.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		C5692F652457874000BD0D8F /* JRSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = C5692F632457874000BD0D8F /* JRSwizzle.m */; };
 		C5692F662457874000BD0D8F /* JRSwizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = C5692F642457874000BD0D8F /* JRSwizzle.h */; };
 		C5A4575A255F0A78005BF9F4 /* MMClippingBezierTodoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C5A45759255F0A78005BF9F4 /* MMClippingBezierTodoTests.m */; };
+		C5A456FC255CCFD4005BF9F4 /* MMClippingBezierIntersectionDirectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C5A456FB255CCFD4005BF9F4 /* MMClippingBezierIntersectionDirectionTests.m */; };
 		C5F904AF2465DD11003D153D /* UIBezierPath+SamplePaths.m in Sources */ = {isa = PBXBuildFile; fileRef = C5F904AE2465DD11003D153D /* UIBezierPath+SamplePaths.m */; };
 		DD26B78DFD8510CCBB10B4D2 /* libPods-ClippingBezier-ClippingBezierTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DB82833120412A4ADC36E802 /* libPods-ClippingBezier-ClippingBezierTests.a */; };
 /* End PBXBuildFile section */
@@ -209,6 +210,7 @@
 		C5692F632457874000BD0D8F /* JRSwizzle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JRSwizzle.m; sourceTree = "<group>"; };
 		C5692F642457874000BD0D8F /* JRSwizzle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JRSwizzle.h; sourceTree = "<group>"; };
 		C5A45759255F0A78005BF9F4 /* MMClippingBezierTodoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMClippingBezierTodoTests.m; sourceTree = "<group>"; };
+		C5A456FB255CCFD4005BF9F4 /* MMClippingBezierIntersectionDirectionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MMClippingBezierIntersectionDirectionTests.m; sourceTree = "<group>"; };
 		C5F904AD2465DD11003D153D /* UIBezierPath+SamplePaths.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBezierPath+SamplePaths.h"; sourceTree = "<group>"; };
 		C5F904AE2465DD11003D153D /* UIBezierPath+SamplePaths.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBezierPath+SamplePaths.m"; sourceTree = "<group>"; };
 		D9EC2CF48A52BA019E4C6A1B /* Pods-ClippingBezier-ClippingBezierTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClippingBezier-ClippingBezierTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ClippingBezier-ClippingBezierTests/Pods-ClippingBezier-ClippingBezierTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -330,6 +332,7 @@
 				665E8D4A1B0D2688009E32FC /* MMClippingBezierTrimmingTests.m */,
 				6696DEE41B2E318A00A2BC8E /* MMClippingBezierGeometryTest.m */,
 				C5A45759255F0A78005BF9F4 /* MMClippingBezierTodoTests.m */,
+				C5A456FB255CCFD4005BF9F4 /* MMClippingBezierIntersectionDirectionTests.m */,
 				662D40D01A8D862600A1CB63 /* Supporting Files */,
 			);
 			path = ClippingBezierTests;
@@ -812,6 +815,7 @@
 				666EEC2E1A8D8F7500B9F171 /* MMClippingBezierSubshapeTests.m in Sources */,
 				666EEC2F1A8D8F7500B9F171 /* MMClippingBezierReversePathTests.m in Sources */,
 				666EEC311A8D8F7500B9F171 /* MMClippingBezierFlatTests.m in Sources */,
+				C5A456FC255CCFD4005BF9F4 /* MMClippingBezierIntersectionDirectionTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClippingBezier/DKUIBezierPathClippedSegment.m
+++ b/ClippingBezier/DKUIBezierPathClippedSegment.m
@@ -159,7 +159,7 @@
  */
 - (CGFloat)angleBetween:(DKUIBezierPathClippedSegment *)otherInter
 {
-    return [[self endVector] angleBetween:[otherInter startVector]];
+    return [[self endVector] angleWithRespectTo:[otherInter startVector]];
 }
 
 - (DKVector *)endVector

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint+Private.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint+Private.h
@@ -9,7 +9,18 @@
 
 @interface DKUIBezierPathIntersectionPoint (Private)
 
-- (id)initWithElementIndex:(NSInteger)index1 andTValue:(CGFloat)_tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)_tValue2 andElementCount1:(NSInteger)_elementCount1 andElementCount2:(NSInteger)_elementCount2 andLengthUntilPath1Loc:(CGFloat)_lenAtInter1 andLengthUntilPath2Loc:(CGFloat)_lenAtInter2;
+- (id)initWithElementIndex:(NSInteger)index1
+                 andTValue:(CGFloat)_tValue1
+          withElementIndex:(NSInteger)index2
+                 andTValue:(CGFloat)_tValue2
+          andElementCount1:(NSInteger)_elementCount1
+          andElementCount2:(NSInteger)_elementCount2
+    andLengthUntilPath1Loc:(CGFloat)_lenAtInter1
+    andLengthUntilPath2Loc:(CGFloat)_lenAtInter2
+            andPathLength1:(CGFloat)pathlen1
+            andPathLength2:(CGFloat)pathlen2
+            andClosedPath1:(BOOL)closed1
+            andClosedPath2:(BOOL)closed2;
 
 - (void)setMayCrossBoundary:(BOOL)mayCrossBoundary;
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint+Private.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint+Private.h
@@ -13,4 +13,6 @@
 
 - (void)setMayCrossBoundary:(BOOL)mayCrossBoundary;
 
+- (void)setDirection:(DKIntersectionDirection)direction;
+
 @end

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.h
@@ -32,6 +32,7 @@
 // might cross from outside to inside the closed shape
 // this is only a hint, and should be verified by the segment
 @property(readonly) BOOL mayCrossBoundary;
+@property(nonatomic, strong) NSMutableSet<DKUIBezierPathIntersectionPoint*>* matchedIntersections;
 
 + (id)intersectionAtElementIndex:(NSInteger)index1 andTValue:(CGFloat)tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)tValue2 andElementCount1:(NSInteger)elementCount1 andElementCount2:(NSInteger)elementCount2 andLengthUntilPath1Loc:(CGFloat)len1 andLengthUntilPath2Loc:(CGFloat)len2;
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.h
@@ -10,9 +10,9 @@
 #import <UIKit/UIKit.h>
 
 typedef CF_ENUM(int32_t, DKIntersectionDirection) {
-    kDKIntersectionDirectionLeft,
-    kDKIntersectionDirectionSame,
-    kDKIntersectionDirectionRight
+    kDKIntersectionDirectionLeft = -1,
+    kDKIntersectionDirectionSame = 0,
+    kDKIntersectionDirectionRight = 1
 };
 
 @interface DKUIBezierPathIntersectionPoint : NSObject

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.h
@@ -9,6 +9,12 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+typedef CF_ENUM(int32_t, DKIntersectionDirection) {
+    kDKIntersectionDirectionLeft,
+    kDKIntersectionDirectionSame,
+    kDKIntersectionDirectionRight
+};
+
 @interface DKUIBezierPathIntersectionPoint : NSObject
 
 @property(readonly) NSInteger elementIndex1;
@@ -32,7 +38,7 @@
 // might cross from outside to inside the closed shape
 // this is only a hint, and should be verified by the segment
 @property(readonly) BOOL mayCrossBoundary;
-@property(nonatomic, strong) NSMutableSet<DKUIBezierPathIntersectionPoint*>* matchedIntersections;
+@property(nonatomic, strong) NSMutableSet<DKUIBezierPathIntersectionPoint *> *matchedIntersections;
 
 + (id)intersectionAtElementIndex:(NSInteger)index1 andTValue:(CGFloat)tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)tValue2 andElementCount1:(NSInteger)elementCount1 andElementCount2:(NSInteger)elementCount2 andLengthUntilPath1Loc:(CGFloat)len1 andLengthUntilPath2Loc:(CGFloat)len2;
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.h
@@ -38,6 +38,7 @@ typedef CF_ENUM(int32_t, DKIntersectionDirection) {
 // might cross from outside to inside the closed shape
 // this is only a hint, and should be verified by the segment
 @property(readonly) BOOL mayCrossBoundary;
+@property(readonly) DKIntersectionDirection direction;
 @property(nonatomic, strong) NSMutableSet<DKUIBezierPathIntersectionPoint *> *matchedIntersections;
 
 + (id)intersectionAtElementIndex:(NSInteger)index1 andTValue:(CGFloat)tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)tValue2 andElementCount1:(NSInteger)elementCount1 andElementCount2:(NSInteger)elementCount2 andLengthUntilPath1Loc:(CGFloat)len1 andLengthUntilPath2Loc:(CGFloat)len2;

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.h
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.h
@@ -30,18 +30,31 @@ typedef CF_ENUM(int32_t, DKIntersectionDirection) {
 // the distance from the start of path2 that we find this intersection
 @property(readonly) CGFloat lenAtInter2;
 // the length of the entire path1, along which this intersection lies
-@property(assign) CGFloat pathLength1;
+@property(readonly) CGFloat pathLength1;
 // the length of the entire path2, along which this intersection lies
-@property(assign) CGFloat pathLength2;
+@property(readonly) CGFloat pathLength2;
 //
 // this signals that a segment with this intersection as the boundary
 // might cross from outside to inside the closed shape
 // this is only a hint, and should be verified by the segment
 @property(readonly) BOOL mayCrossBoundary;
 @property(readonly) DKIntersectionDirection direction;
+@property(readonly) BOOL pathClosed1;
+@property(readonly) BOOL pathClosed2;
 @property(nonatomic, strong) NSMutableSet<DKUIBezierPathIntersectionPoint *> *matchedIntersections;
 
-+ (id)intersectionAtElementIndex:(NSInteger)index1 andTValue:(CGFloat)tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)tValue2 andElementCount1:(NSInteger)elementCount1 andElementCount2:(NSInteger)elementCount2 andLengthUntilPath1Loc:(CGFloat)len1 andLengthUntilPath2Loc:(CGFloat)len2;
++ (id)intersectionAtElementIndex:(NSInteger)index1
+                       andTValue:(CGFloat)tValue1
+                withElementIndex:(NSInteger)index2
+                       andTValue:(CGFloat)tValue2
+                andElementCount1:(NSInteger)elementCount1
+                andElementCount2:(NSInteger)elementCount2
+          andLengthUntilPath1Loc:(CGFloat)len1
+          andLengthUntilPath2Loc:(CGFloat)len2
+                  andPathLength1:(CGFloat)pathlen1
+                  andPathLength2:(CGFloat)pathlen2
+                  andClosedPath1:(BOOL)closed1
+                  andClosedPath2:(BOOL)closed2;
 
 - (DKUIBezierPathIntersectionPoint *)flipped;
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.m
@@ -62,13 +62,14 @@
         elementCount2 = _elementCount2;
         lenAtInter1 = _lenAtInter1;
         lenAtInter2 = _lenAtInter2;
+        _matchedIntersections = [[NSMutableSet alloc] init];
     }
     return self;
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"[Intersection (%d %f) (%d %f)]", (int)elementIndex1, tValue1, (int)elementIndex2, tValue2];
+    return [NSString stringWithFormat:@"[Intersection (%d %f) (%d %f) %d]", (int)elementIndex1, tValue1, (int)elementIndex2, tValue2, mayCrossBoundary];
 }
 
 - (void)dealloc
@@ -103,6 +104,12 @@
     ret.mayCrossBoundary = self.mayCrossBoundary;
     ret.pathLength1 = self.pathLength2;
     ret.pathLength2 = self.pathLength1;
+
+    NSMutableArray<DKUIBezierPathIntersectionPoint *> *flippedPoints = [NSMutableArray array];
+    for (DKUIBezierPathIntersectionPoint *p in self.matchedIntersections) {
+        [flippedPoints addObject:[p flipped]];
+    }
+    [ret.matchedIntersections addObjectsFromArray:flippedPoints];
     return ret;
 }
 
@@ -263,6 +270,10 @@
             [self roundedTValue:self.tValue1] == [self roundedTValue:other.tValue1] &&
             self.elementIndex2 == other.elementIndex2 &&
             [self roundedTValue:self.tValue2] == [self roundedTValue:other.tValue2]) {
+            return YES;
+        } else if ([_matchedIntersections containsObject:other]) {
+            return YES;
+        } else if ([[other matchedIntersections] containsObject:self]) {
             return YES;
         }
     }

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.m
@@ -94,7 +94,7 @@
         _pathClosed1 = closed1;
         _pathClosed2 = closed2;
         _pathLength1 = pathlen1;
-        _pathLength2 = pathlen1;
+        _pathLength2 = pathlen2;
         _matchedIntersections = [[NSMutableSet alloc] init];
     }
     return self;
@@ -170,7 +170,7 @@
     CGFloat otherDistFromEnd2 = [other pathClosed2] ? MIN(other.lenAtInter2, ABS(other.pathLength2 - other.lenAtInter2)) : other.lenAtInter2;
     CGFloat compare2 = ABS(myDistFromEnd2 - otherDistFromEnd2);
 
-    return compare1 < precision && compare2 < precision;
+    return (compare1 < precision && compare2 < precision);
 }
 
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.m
@@ -11,6 +11,8 @@
 #import "DKUIBezierPathIntersectionPoint+Private.h"
 #import <PerformanceBezier/PerformanceBezier.h>
 
+#define kUIBezierClosenessPrecision 0.5
+
 @implementation DKUIBezierPathIntersectionPoint {
     NSInteger elementIndex1;
     CGFloat tValue1;
@@ -131,8 +133,8 @@
                                                                                       andElementCount2:elementCount1
                                                                                 andLengthUntilPath1Loc:lenAtInter2
                                                                                 andLengthUntilPath2Loc:lenAtInter1
-                                                                                        andPathLength1:self.pathLength1
-                                                                                        andPathLength2:self.pathLength2
+                                                                                        andPathLength1:self.pathLength2
+                                                                                        andPathLength2:self.pathLength1
                                                                                         andClosedPath1:self.pathClosed2
                                                                                         andClosedPath2:self.pathClosed1];
     ret.bez1[0] = self.bez2[0];
@@ -164,10 +166,25 @@
 {
     CGFloat myDistFromEnd1 = [self pathClosed1] ? MIN(self.lenAtInter1, ABS(self.pathLength1 - self.lenAtInter1)) : self.lenAtInter1;
     CGFloat otherDistFromEnd1 = [other pathClosed1] ? MIN(other.lenAtInter1, ABS(other.pathLength1 - other.lenAtInter1)) : other.lenAtInter1;
-    CGFloat compare1 = ABS(myDistFromEnd1 - otherDistFromEnd1);
-
     CGFloat myDistFromEnd2 = [self pathClosed2] ? MIN(self.lenAtInter2, ABS(self.pathLength2 - self.lenAtInter2)) : self.lenAtInter2;
     CGFloat otherDistFromEnd2 = [other pathClosed2] ? MIN(other.lenAtInter2, ABS(other.pathLength2 - other.lenAtInter2)) : other.lenAtInter2;
+
+    // account for the closed path. when these are true, it means we've found
+    // the shortest length by looping backward around the path
+    if (myDistFromEnd1 < lenAtInter1) {
+        myDistFromEnd1 = -myDistFromEnd1;
+    }
+    if (otherDistFromEnd1 < other.lenAtInter1) {
+        otherDistFromEnd1 = -otherDistFromEnd1;
+    }
+    if (myDistFromEnd2 < lenAtInter2) {
+        myDistFromEnd2 = -myDistFromEnd2;
+    }
+    if (otherDistFromEnd2 < other.lenAtInter2) {
+        otherDistFromEnd2 = -otherDistFromEnd2;
+    }
+
+    CGFloat compare1 = ABS(myDistFromEnd1 - otherDistFromEnd1);
     CGFloat compare2 = ABS(myDistFromEnd2 - otherDistFromEnd2);
 
     return (compare1 < precision && compare2 < precision);
@@ -221,6 +238,10 @@
         self.tValue2 == [obj tValue2]) {
         ret = YES;
     }
+    if (!ret) {
+        //        ret = [self isCloseToIntersection:obj withPrecision:kUIBezierClosenessPrecision] && [self direction] == [obj direction];
+    }
+
     return ret;
 }
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.m
@@ -83,6 +83,11 @@
     mayCrossBoundary = _mayCrossBoundary;
 }
 
+- (void)setDirection:(DKIntersectionDirection)direction
+{
+    _direction = direction;
+}
+
 - (DKUIBezierPathIntersectionPoint *)flipped
 {
     DKUIBezierPathIntersectionPoint *ret = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:self.elementIndex2
@@ -102,6 +107,7 @@
     ret.bez2[2] = self.bez1[2];
     ret.bez2[3] = self.bez1[3];
     ret.mayCrossBoundary = self.mayCrossBoundary;
+    ret.direction = self.direction;
     ret.pathLength1 = self.pathLength2;
     ret.pathLength2 = self.pathLength1;
 
@@ -299,6 +305,13 @@
     result = prime * result + self.elementCount2;
     result = prime * result + self.tValue2;
     result = prime * result + ((self.mayCrossBoundary) ? 1231 : 1237);
+    if (self.direction == kDKIntersectionDirectionLeft) {
+        result = prime * result + 1231;
+    } else if (self.direction == kDKIntersectionDirectionRight) {
+        result = prime * result + 1237;
+    } else {
+        result = prime * result + 1327;
+    }
     return result;
 }
 

--- a/ClippingBezier/DKUIBezierPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierPathIntersectionPoint.m
@@ -69,7 +69,7 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"[Intersection (%d %f) (%d %f) %d]", (int)elementIndex1, tValue1, (int)elementIndex2, tValue2, mayCrossBoundary];
+    return [NSString stringWithFormat:@"[Intersection (%d %f) (%d %f) b:%d d:%d]", (int)elementIndex1, tValue1, (int)elementIndex2, tValue2, mayCrossBoundary, _direction];
 }
 
 - (void)dealloc

--- a/ClippingBezier/DKUIBezierPathShape.h
+++ b/ClippingBezier/DKUIBezierPathShape.h
@@ -23,6 +23,7 @@
 - (DKUIBezierPathIntersectionPoint *)endingPoint;
 - (BOOL)isClosed;
 - (UIBezierPath *)fullPath;
+- (NSSet<DKUIBezierPathIntersectionPoint*>*) intersections;
 
 - (BOOL)isSameShapeAs:(DKUIBezierPathShape *)otherShape;
 

--- a/ClippingBezier/DKUIBezierPathShape.m
+++ b/ClippingBezier/DKUIBezierPathShape.m
@@ -236,5 +236,21 @@
     return unionShape;
 }
 
+- (NSSet<DKUIBezierPathIntersectionPoint *> *)intersections
+{
+    NSMutableSet<DKUIBezierPathIntersectionPoint *> *intersections = [[NSMutableSet alloc] init];
+
+    for (DKUIBezierPathClippedSegment *segment in segments) {
+        [intersections addObject:[segment startIntersection]];
+        [intersections addObject:[segment endIntersection]];
+    }
+
+    return intersections;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"[Shape: %@]", segments];
+}
 
 @end

--- a/ClippingBezier/DKUIBezierPathShape.m
+++ b/ClippingBezier/DKUIBezierPathShape.m
@@ -38,7 +38,8 @@
 
 - (BOOL)isClosed
 {
-    return [[self startingPoint] matchesElementEndpointWithIntersection:[self endingPoint]];
+    return [[self startingPoint] matchesElementEndpointWithIntersection:[self endingPoint]] ||
+        [[self startingPoint] isEqualToIntersection:[self endingPoint]];
 }
 
 - (UIBezierPath *)fullPath
@@ -145,17 +146,17 @@
 
 - (DKUIBezierPathShape *)reversedShape
 {
-    DKUIBezierPathShape *flipped = [[DKUIBezierPathShape alloc] init];
+    DKUIBezierPathShape *reversed = [[DKUIBezierPathShape alloc] init];
 
     [[self segments] enumerateObjectsUsingBlock:^(DKUIBezierPathClippedSegment *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-        [[flipped segments] insertObject:[obj reversedSegment] atIndex:0];
+        [[reversed segments] insertObject:[obj reversedSegment] atIndex:0];
     }];
 
     [[self holes] enumerateObjectsUsingBlock:^(DKUIBezierPathShape *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-        [[flipped holes] addObject:[obj reversedShape]];
+        [[reversed holes] addObject:[obj reversedShape]];
     }];
 
-    return flipped;
+    return reversed;
 }
 
 #pragma mark - Merge Shapes

--- a/ClippingBezier/DKUIBezierUnmatchedPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierUnmatchedPathIntersectionPoint.m
@@ -17,12 +17,45 @@ static NSUInteger uniqueIntersectionIdGeneration = 0;
 
 @synthesize uniqueUnmatchedIntersectionId;
 
-+ (id)intersectionAtElementIndex:(NSInteger)index1 andTValue:(CGFloat)_tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)_tValue2 andElementCount1:(NSInteger)_elementCount1 andElementCount2:(NSInteger)_elementCount2 andLengthUntilPath1Loc:(CGFloat)_lenAtInter1 andLengthUntilPath2Loc:(CGFloat)_lenAtInter2
++ (id)intersectionAtElementIndex:(NSInteger)index1
+                       andTValue:(CGFloat)_tValue1
+                withElementIndex:(NSInteger)index2
+                       andTValue:(CGFloat)_tValue2
+                andElementCount1:(NSInteger)_elementCount1
+                andElementCount2:(NSInteger)_elementCount2
+          andLengthUntilPath1Loc:(CGFloat)_lenAtInter1
+          andLengthUntilPath2Loc:(CGFloat)_lenAtInter2
+                  andPathLength1:(CGFloat)pathlen1
+                  andPathLength2:(CGFloat)pathlen2
+                  andClosedPath1:(BOOL)closed1
+                  andClosedPath2:(BOOL)closed2
 {
-    return [[DKUIBezierUnmatchedPathIntersectionPoint alloc] initWithElementIndex:index1 andTValue:_tValue1 withElementIndex:index2 andTValue:_tValue2 andElementCount1:_elementCount1 andElementCount2:_elementCount2 andLengthUntilPath1Loc:_lenAtInter1 andLengthUntilPath2Loc:_lenAtInter2];
+    return [[DKUIBezierUnmatchedPathIntersectionPoint alloc] initWithElementIndex:index1
+                                                                        andTValue:_tValue1
+                                                                 withElementIndex:index2
+                                                                        andTValue:_tValue2
+                                                                 andElementCount1:_elementCount1
+                                                                 andElementCount2:_elementCount2
+                                                           andLengthUntilPath1Loc:_lenAtInter1
+                                                           andLengthUntilPath2Loc:_lenAtInter2
+                                                                   andPathLength1:pathlen1
+                                                                   andPathLength2:pathlen2
+                                                                   andClosedPath1:closed1
+                                                                   andClosedPath2:closed2];
 }
 
-- (id)initWithElementIndex:(NSInteger)index1 andTValue:(CGFloat)_tValue1 withElementIndex:(NSInteger)index2 andTValue:(CGFloat)_tValue2 andElementCount1:(NSInteger)_elementCount1 andElementCount2:(NSInteger)_elementCount2 andLengthUntilPath1Loc:(CGFloat)_lenAtInter1 andLengthUntilPath2Loc:(CGFloat)_lenAtInter2
+- (id)initWithElementIndex:(NSInteger)index1
+                 andTValue:(CGFloat)_tValue1
+          withElementIndex:(NSInteger)index2
+                 andTValue:(CGFloat)_tValue2
+          andElementCount1:(NSInteger)_elementCount1
+          andElementCount2:(NSInteger)_elementCount2
+    andLengthUntilPath1Loc:(CGFloat)_lenAtInter1
+    andLengthUntilPath2Loc:(CGFloat)_lenAtInter2
+            andPathLength1:(CGFloat)pathlen1
+            andPathLength2:(CGFloat)pathlen2
+            andClosedPath1:(BOOL)closed1
+            andClosedPath2:(BOOL)closed2
 {
     if (self = [super initWithElementIndex:index1
                                  andTValue:_tValue1
@@ -31,7 +64,11 @@ static NSUInteger uniqueIntersectionIdGeneration = 0;
                           andElementCount1:_elementCount1
                           andElementCount2:_elementCount2
                     andLengthUntilPath1Loc:_lenAtInter1
-                    andLengthUntilPath2Loc:_lenAtInter2]) {
+                    andLengthUntilPath2Loc:_lenAtInter2
+                            andPathLength1:pathlen1
+                            andPathLength2:pathlen2
+                            andClosedPath1:closed1
+                            andClosedPath2:closed2]) {
         @synchronized([DKUIBezierUnmatchedPathIntersectionPoint class])
         {
             [self setUniqueId:uniqueIntersectionIdGeneration];
@@ -61,7 +98,11 @@ static NSUInteger uniqueIntersectionIdGeneration = 0;
                                                                                                         andElementCount1:self.elementCount2
                                                                                                         andElementCount2:self.elementCount1
                                                                                                   andLengthUntilPath1Loc:self.lenAtInter2
-                                                                                                  andLengthUntilPath2Loc:self.lenAtInter1];
+                                                                                                  andLengthUntilPath2Loc:self.lenAtInter1
+                                                                                                          andPathLength1:self.pathLength1
+                                                                                                          andPathLength2:self.pathLength2
+                                                                                                          andClosedPath1:self.pathClosed2
+                                                                                                          andClosedPath2:self.pathClosed1];
     ret.bez1[0] = self.bez2[0];
     ret.bez1[1] = self.bez2[1];
     ret.bez1[2] = self.bez2[2];
@@ -72,8 +113,6 @@ static NSUInteger uniqueIntersectionIdGeneration = 0;
     ret.bez2[3] = self.bez1[3];
     ret.mayCrossBoundary = self.mayCrossBoundary;
     ret.direction = self.direction;
-    ret.pathLength1 = self.pathLength2;
-    ret.pathLength2 = self.pathLength1;
     [ret setUniqueId:self.uniqueUnmatchedIntersectionId];
     return ret;
 }

--- a/ClippingBezier/DKUIBezierUnmatchedPathIntersectionPoint.m
+++ b/ClippingBezier/DKUIBezierUnmatchedPathIntersectionPoint.m
@@ -71,6 +71,7 @@ static NSUInteger uniqueIntersectionIdGeneration = 0;
     ret.bez2[2] = self.bez1[2];
     ret.bez2[3] = self.bez1[3];
     ret.mayCrossBoundary = self.mayCrossBoundary;
+    ret.direction = self.direction;
     ret.pathLength1 = self.pathLength2;
     ret.pathLength2 = self.pathLength1;
     [ret setUniqueId:self.uniqueUnmatchedIntersectionId];

--- a/ClippingBezier/DKVector.h
+++ b/ClippingBezier/DKVector.h
@@ -44,7 +44,15 @@
 
 - (CGPoint)mirrorPoint:(CGPoint)point aroundPoint:(CGPoint)startPoint;
 
-- (CGFloat)angleBetween:(DKVector *)otherVector;
+- (CGFloat)angleWithRespectTo:(DKVector *)otherVector;
+
+- (DKVector *)projectedOnto:(DKVector *)other;
+
+- (DKVector *)add:(DKVector *)v;
+
+- (DKVector *)scale:(CGFloat)c;
+
+- (CGFloat)dot:(DKVector *)other;
 
 - (CGPoint)asCGPoint;
 @end

--- a/ClippingBezier/DKVector.m
+++ b/ClippingBezier/DKVector.m
@@ -132,7 +132,8 @@
     return CGPointMake(x2, y2);
 }
 
-- (CGFloat)angleBetween:(DKVector *)otherVector
+/// Returns the angle of the input vector with respect to this vector.
+- (CGFloat)angleWithRespectTo:(DKVector *)otherVector
 {
     // angle with +ve x-axis, in the range (−π, π]
     float thetaA = atan2(otherVector.x, otherVector.y);
@@ -153,6 +154,31 @@
     //    CGFloat angleBetween = acosf(scaler / (self.magnitude * otherVector.magnitude));
     //    return roundf(angleBetween * pow(10, 6)) / pow(10, 6);
 }
+
+- (CGFloat)dot:(DKVector *)other
+{
+    return self.x * other.x + self.y * other.y;
+}
+
+- (DKVector *)scale:(CGFloat)c
+{
+    return [DKVector vectorWithX:x * c andY:y * c];
+}
+
+- (DKVector *)projectedOnto:(DKVector *)v
+{
+    CGFloat dp = [v dot:self];
+    CGFloat vv = [v dot:v];
+    CGFloat c = dp / vv;
+
+    return [v scale:c];
+}
+
+- (DKVector *)add:(DKVector *)v
+{
+    return [DKVector vectorWithX:x + v.x andY:y + v.y];
+}
+
 
 - (CGPoint)asCGPoint
 {

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -387,7 +387,12 @@ static NSInteger segmentCompareCount = 0;
             if (isDistinctIntersection) {
                 lastInter = obj;
             } else if (lastInter != obj) {
-                [[lastInter matchedIntersections] addObject:obj];
+                if ([lastInter direction] == [intersection direction]) {
+                    [[lastInter matchedIntersections] addObject:obj];
+                } else {
+                    isDistinctIntersection = YES;
+                    lastInter = obj;
+                }
             }
             return isDistinctIntersection;
         }]]];

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -349,6 +349,10 @@ static NSInteger segmentCompareCount = 0;
                     isDistinctIntersection = !closeLocation1 || !closeLocation2;
                 }
             }
+            // I also need to test if the direction of the boundary crossing is
+            // the same direction. if they both go from outside->inside or inside->outside
+            // then they're duplicate. otherwise it's a very very close out -> in -> out crossing
+            // or in -> out -> in crossing
             if (isDistinctIntersection) {
                 lastInter = obj;
             } else {

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -107,6 +107,15 @@ static NSInteger segmentCompareCount = 0;
     } else if ([self isFlat] && ![closedPath isFlat]) {
         path1 = self;
         path2 = closedPath;
+    } else if ([closedPath length] == [self length]) {
+        if ([closedPath hash] < [self hash]) {
+            path1 = closedPath;
+            path2 = self;
+            didFlipPathNumbers = YES;
+        } else {
+            path1 = self;
+            path2 = closedPath;
+        }
     } else if ([closedPath length] > [self length]) {
         path1 = closedPath;
         path2 = self;

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -355,7 +355,7 @@ static NSInteger segmentCompareCount = 0;
             // or in -> out -> in crossing
             if (isDistinctIntersection) {
                 lastInter = obj;
-            } else {
+            } else if (lastInter != obj) {
                 [[lastInter matchedIntersections] addObject:obj];
             }
             return isDistinctIntersection;

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -508,6 +508,8 @@ static NSInteger segmentCompareCount = 0;
                     intersection.mayCrossBoundary = isInside != isInsideAfterIntersection;
                 }
 
+                // TODO: detect the direction that the intersection moves.
+
                 // setup for next iteration of loop
                 lastIntersection = intersection;
                 isInside = isInsideAfterIntersection;
@@ -850,6 +852,7 @@ static NSInteger segmentCompareCount = 0;
                                                                                                          andLengthUntilPath1Loc:oldInter.lenAtInter1
                                                                                                          andLengthUntilPath2Loc:oldInter.lenAtInter2];
                         [newInter setMayCrossBoundary:oldInter.mayCrossBoundary];
+                        [newInter setDirection:oldInter.direction];
                         newInter.pathLength1 = oldInter.pathLength1;
                         newInter.pathLength2 = oldInter.pathLength2;
                         [tValuesOfIntersectionPoints replaceObjectAtIndex:i withObject:newInter];
@@ -1217,14 +1220,14 @@ static NSInteger segmentCompareCount = 0;
     // because we're going to reuse and resort the tValuesOfIntersectionPoints1.
     // this solves rounding error that happens when intersections generate slightly differently
     // depending on the order of paths sent in
-    NSArray *intersectionsWithBoundaryInformation = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil];
+    NSArray<DKUIBezierPathIntersectionPoint *> *intersectionsWithBoundaryInformation = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil];
     //
     // this array will be the intersections between the shape and the scissor.
     // we'll use the exact same intersection objects (flipped, b/c we're attacking from
     // the shape v scissor instead of vice versa). We'll need to order them and
     // set the mayCrossBoundary so that the final array will appear as if it came
     // directly from [shapePath findIntersectionsWithClosedPath:scissorPath...]
-    NSMutableArray *shapeToScissorIntersections = [NSMutableArray array];
+    NSMutableArray<DKUIBezierPathIntersectionPoint *> *shapeToScissorIntersections = [NSMutableArray array];
     // 1. flip
     [scissorToShapeIntersections enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         [shapeToScissorIntersections addObject:[obj flipped]];
@@ -1246,6 +1249,7 @@ static NSInteger segmentCompareCount = 0;
     // 3. fix mayCrossBoundary:
     for (int i = 0; i < [intersectionsWithBoundaryInformation count]; i++) {
         [[shapeToScissorIntersections objectAtIndex:i] setMayCrossBoundary:[[intersectionsWithBoundaryInformation objectAtIndex:i] mayCrossBoundary]];
+        [[shapeToScissorIntersections objectAtIndex:i] setDirection:[[intersectionsWithBoundaryInformation objectAtIndex:i] direction]];
     }
 
     //

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -349,6 +349,37 @@ static NSInteger segmentCompareCount = 0;
                     isDistinctIntersection = !closeLocation1 || !closeLocation2;
                 }
             }
+
+            // Using the following tangents, determine if the intersection is entering or leaving the shape
+            // or if the intersection is tangent to the shape.
+            CGPoint shapeCGTan = [closedPath tangentOnPathAtElement:intersection.elementIndex2 andTValue:intersection.tValue2];
+            CGPoint myCGTan = [self tangentOnPathAtElement:intersection.elementIndex1 andTValue:intersection.tValue1];
+
+            DKVector *shapeTan = [DKVector vectorWithX:shapeCGTan.x andY:shapeCGTan.y];
+            DKVector *myTan = [DKVector vectorWithX:myCGTan.x andY:myCGTan.y];
+            CGFloat angle = [myTan angleWithRespectTo:shapeTan];
+            const CGFloat marginOfErr = 0.00001;
+
+            if (angle < -marginOfErr) {
+                // the angle is negative, so myTan is aiming to the right of shapeTan
+                // our path is moving /outside/ => /inside/ of closedPath
+                [intersection setDirection:kDKIntersectionDirectionRight];
+            } else if (angle > marginOfErr) {
+                // the angle is positive, so myTan is aiming to the left of shapeTan
+                [intersection setDirection:kDKIntersectionDirectionLeft];
+                // our path is moving /inside/ => /outside/ of closedPath
+            } else if (angle >= -marginOfErr && angle <= marginOfErr) {
+                // our path is tangent to the closed path, and we're in the same direction
+                [intersection setDirection:kDKIntersectionDirectionSame];
+            } else if (angle >= M_PI - marginOfErr || angle <= -M_PI + marginOfErr) {
+                // our path is tangent to the closed path, and we're in the opposite direction
+                [intersection setDirection:kDKIntersectionDirectionSame];
+            } else {
+                // an unknown error occurred
+                assert("angle should be between -M_PI and M_PI");
+                [intersection setDirection:kDKIntersectionDirectionSame];
+            }
+
             // I also need to test if the direction of the boundary crossing is
             // the same direction. if they both go from outside->inside or inside->outside
             // then they're duplicate. otherwise it's a very very close out -> in -> out crossing
@@ -522,6 +553,26 @@ static NSInteger segmentCompareCount = 0;
     return [NSArray array];
 }
 
+- (CGFloat)angleBetween:(CGVector)v1 and:(CGVector)v2
+{
+    if ((v1.dx == 0 && v1.dy == 0) || (v2.dx == 0 && v2.dy == 0)) {
+        return NAN;
+    }
+    // angle with +ve x-axis, in the range (−π, π]
+    float thetaA = atan2(v2.dx, v2.dy);
+    float thetaB = atan2(v1.dx, v1.dy);
+
+    float thetaAB = thetaB - thetaA;
+
+    // get in range (−π, π]
+    while (thetaAB <= -M_PI)
+        thetaAB += 2 * M_PI;
+
+    while (thetaAB > M_PI)
+        thetaAB -= 2 * M_PI;
+
+    return thetaAB;
+}
 
 #pragma mark - Segment Finding
 
@@ -1568,7 +1619,7 @@ static NSInteger segmentCompareCount = 0;
         DKUIBezierPathIntersectionPoint *end2 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:scissors.elementCount - 1 andTValue:1 withElementIndex:-1 andTValue:-1 andElementCount1:scissors.elementCount andElementCount2:self.elementCount andLengthUntilPath1Loc:0 andLengthUntilPath2Loc:-1];
         DKUIBezierPathClippedSegment *segment2 = [DKUIBezierPathClippedSegment clippedPairWithStart:start2 andEnd:end2 andPathSegment:[scissors copy] fromFullPath:scissors];
         DKUIBezierPathShape *shape2 = [[DKUIBezierPathShape alloc] init];
-        [shape1.segments addObject:segment2];
+        [shape2.segments addObject:segment2];
 
         if ([self containsPoint:[scissors firstPoint]] || [scissors containsPoint:[self firstPoint]]) {
             // the paths contain each other, return the largest
@@ -1915,9 +1966,9 @@ static NSInteger segmentCompareCount = 0;
                     DKVector *currSeg = [[segment pathSegment] tangentNearEnd].tangent;
                     DKVector *currPoss = [[blueSeg pathSegment] tangentNearStart].tangent;
                     //                        NSLog(@"angle: %f", [currSeg angleBetween:currPoss]);
-                    if ([UIBezierPath round:[currSeg angleBetween:currPoss] to:6] == [UIBezierPath round:M_PI to:6]) {
+                    if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:M_PI to:6]) {
                         // never allow exactly backwards tangents
-                    } else if ([UIBezierPath round:[currSeg angleBetween:currPoss] to:6] == [UIBezierPath round:-M_PI to:6]) {
+                    } else if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:-M_PI to:6]) {
                         // never allow exactly backwards tangents
                     } else {
                         currentSegmentCandidate = blueSeg;
@@ -1929,8 +1980,8 @@ static NSInteger segmentCompareCount = 0;
                     DKVector *newPoss = [[blueSeg pathSegment] tangentNearStart].tangent;
                     //                        NSLog(@"angle: %f vs %f", [currSeg angleBetween:currPoss], [currSeg angleBetween:newPoss]);
                     if (gt) {
-                        if ([currSeg angleBetween:newPoss] > [currSeg angleBetween:currPoss]) {
-                            if ([UIBezierPath round:[currSeg angleBetween:newPoss] to:3] == [UIBezierPath round:M_PI to:3]) {
+                        if ([currSeg angleWithRespectTo:newPoss] > [currSeg angleWithRespectTo:currPoss]) {
+                            if ([UIBezierPath round:[currSeg angleWithRespectTo:newPoss] to:3] == [UIBezierPath round:M_PI to:3]) {
                                 // never allow exactly backwards tangents
                             } else {
                                 currentSegmentCandidate = blueSeg;
@@ -1938,8 +1989,8 @@ static NSInteger segmentCompareCount = 0;
                             }
                         }
                     } else {
-                        if ([currSeg angleBetween:newPoss] < [currSeg angleBetween:currPoss]) {
-                            if ([UIBezierPath round:[currSeg angleBetween:newPoss] to:3] == [UIBezierPath round:-M_PI to:3]) {
+                        if ([currSeg angleWithRespectTo:newPoss] < [currSeg angleWithRespectTo:currPoss]) {
+                            if ([UIBezierPath round:[currSeg angleWithRespectTo:newPoss] to:3] == [UIBezierPath round:-M_PI to:3]) {
                                 // never allow exactly backwards tangents
                             } else {
                                 currentSegmentCandidate = blueSeg;
@@ -1966,9 +2017,9 @@ static NSInteger segmentCompareCount = 0;
                 DKVector *currSeg = [[segment pathSegment] tangentNearEnd].tangent;
                 DKVector *currPoss = [[redSeg pathSegment] tangentNearStart].tangent;
                 //                    NSLog(@"angle: %f", [currSeg angleBetween:currPoss]);
-                if ([UIBezierPath round:[currSeg angleBetween:currPoss] to:6] == [UIBezierPath round:M_PI to:6]) {
+                if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:M_PI to:6]) {
                     // never allow exactly backwards tangents
-                } else if ([UIBezierPath round:[currSeg angleBetween:currPoss] to:6] == [UIBezierPath round:-M_PI to:6]) {
+                } else if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:-M_PI to:6]) {
                     // never allow exactly backwards tangents
                 } else {
                     currentSegmentCandidate = redSeg;
@@ -1979,8 +2030,8 @@ static NSInteger segmentCompareCount = 0;
                 DKVector *currPoss = [[currentSegmentCandidate pathSegment] tangentNearStart].tangent;
                 DKVector *newPoss = [[redSeg pathSegment] tangentNearStart].tangent;
                 if (gt) {
-                    if ([currSeg angleBetween:newPoss] >= [currSeg angleBetween:currPoss]) {
-                        if ([UIBezierPath round:[currSeg angleBetween:newPoss] to:3] == [UIBezierPath round:M_PI to:3]) {
+                    if ([currSeg angleWithRespectTo:newPoss] >= [currSeg angleWithRespectTo:currPoss]) {
+                        if ([UIBezierPath round:[currSeg angleWithRespectTo:newPoss] to:3] == [UIBezierPath round:M_PI to:3]) {
                             // never allow exactly backwards tangents
                         } else {
                             currentSegmentCandidate = redSeg;
@@ -1988,8 +2039,8 @@ static NSInteger segmentCompareCount = 0;
                         }
                     }
                 } else {
-                    if ([currSeg angleBetween:newPoss] <= [currSeg angleBetween:currPoss]) {
-                        if ([UIBezierPath round:[currSeg angleBetween:newPoss] to:3] == [UIBezierPath round:-M_PI to:3]) {
+                    if ([currSeg angleWithRespectTo:newPoss] <= [currSeg angleWithRespectTo:currPoss]) {
+                        if ([UIBezierPath round:[currSeg angleWithRespectTo:newPoss] to:3] == [UIBezierPath round:-M_PI to:3]) {
                             // never allow exactly backwards tangents
                         } else {
                             currentSegmentCandidate = redSeg;

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -342,10 +342,6 @@ static NSInteger segmentCompareCount = 0;
                     BOOL closeLocation1 = [lastInter isCloseToIntersection:intersection withPrecision:kUIBezierClosenessPrecision];
                     BOOL closeLocation2 = [[lastInter flipped] isCloseToIntersection:[intersection flipped] withPrecision:kUIBezierClosenessPrecision];
 
-                    if (closeLocation1 != closeLocation2) {
-                        NSLog(@"gotcha");
-                    }
-
                     isDistinctIntersection = !closeLocation1 || !closeLocation2;
                 }
             }
@@ -380,6 +376,12 @@ static NSInteger segmentCompareCount = 0;
                 [intersection setDirection:kDKIntersectionDirectionSame];
             }
 
+            // if the intersection is extremely close to another intersection, but changes the direction
+            // that the path enters/leaves the closed path, then we should keep it.
+            BOOL directionChanged = [lastInter direction] != [intersection direction] && [intersection direction] != kDKIntersectionDirectionSame;
+
+            isDistinctIntersection = isDistinctIntersection || directionChanged;
+
             // I also need to test if the direction of the boundary crossing is
             // the same direction. if they both go from outside->inside or inside->outside
             // then they're duplicate. otherwise it's a very very close out -> in -> out crossing
@@ -387,12 +389,7 @@ static NSInteger segmentCompareCount = 0;
             if (isDistinctIntersection) {
                 lastInter = obj;
             } else if (lastInter != obj) {
-                if ([lastInter direction] == [intersection direction]) {
-                    [[lastInter matchedIntersections] addObject:obj];
-                } else {
-                    isDistinctIntersection = YES;
-                    lastInter = obj;
-                }
+                [[lastInter matchedIntersections] addObject:obj];
             }
             return isDistinctIntersection;
         }]]];
@@ -1879,8 +1876,6 @@ static NSInteger segmentCompareCount = 0;
             //            [output addObject:currentlyBuiltShape];
             [usedBlueSegments removeAllObjects];
         } else {
-            //            NSLog(@"adding shape");
-
             NSIndexSet *indexes = [currentlyBuiltShape.segments indexesOfObjectsPassingTest:^(id obj, NSUInteger idx, BOOL *stop) {
                 // all shape segments, when blue, will have been flipped
                 return (BOOL)([intersectionsOfShell containsObject:[[obj startIntersection] flipped]] ||
@@ -1918,10 +1913,6 @@ static NSInteger segmentCompareCount = 0;
         }
         [allUnusedBlueSegments removeObjectsInArray:usedBlueSegments];
     }
-
-    //    NSLog(@"found shapes: %@", output);
-    //    NSLog(@"found possible holes: %@", holesInNewShapes);
-    //    NSLog(@"still have %d unused blue segments", [allUnusedBlueSegments count]);
 
     for (DKUIBezierPathShape *potentialHole in [holesInNewShapes copy]) {
         // make sure the probable hole is actually a hole, and that
@@ -1970,7 +1961,6 @@ static NSInteger segmentCompareCount = 0;
                 if (!currentSegmentCandidate) {
                     DKVector *currSeg = [[segment pathSegment] tangentNearEnd].tangent;
                     DKVector *currPoss = [[blueSeg pathSegment] tangentNearStart].tangent;
-                    //                        NSLog(@"angle: %f", [currSeg angleBetween:currPoss]);
                     if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:M_PI to:6]) {
                         // never allow exactly backwards tangents
                     } else if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:-M_PI to:6]) {
@@ -1983,7 +1973,6 @@ static NSInteger segmentCompareCount = 0;
                     DKVector *currSeg = [[segment pathSegment] tangentNearEnd].tangent;
                     DKVector *currPoss = [[currentSegmentCandidate pathSegment] tangentNearStart].tangent;
                     DKVector *newPoss = [[blueSeg pathSegment] tangentNearStart].tangent;
-                    //                        NSLog(@"angle: %f vs %f", [currSeg angleBetween:currPoss], [currSeg angleBetween:newPoss]);
                     if (gt) {
                         if ([currSeg angleWithRespectTo:newPoss] > [currSeg angleWithRespectTo:currPoss]) {
                             if ([UIBezierPath round:[currSeg angleWithRespectTo:newPoss] to:3] == [UIBezierPath round:M_PI to:3]) {
@@ -2021,7 +2010,6 @@ static NSInteger segmentCompareCount = 0;
             if (!currentSegmentCandidate) {
                 DKVector *currSeg = [[segment pathSegment] tangentNearEnd].tangent;
                 DKVector *currPoss = [[redSeg pathSegment] tangentNearStart].tangent;
-                //                    NSLog(@"angle: %f", [currSeg angleBetween:currPoss]);
                 if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:M_PI to:6]) {
                     // never allow exactly backwards tangents
                 } else if ([UIBezierPath round:[currSeg angleWithRespectTo:currPoss] to:6] == [UIBezierPath round:-M_PI to:6]) {

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -306,58 +306,15 @@ static NSInteger segmentCompareCount = 0;
             return NSOrderedDescending;
         }];
 
-        [foundIntersections enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            DKUIBezierPathIntersectionPoint *intersection = obj;
-            if (!didFlipPathNumbers) {
-                intersection.pathLength1 = path1EstimatedLength;
-                intersection.pathLength2 = path2EstimatedLength;
-            } else {
-                intersection.pathLength1 = path2EstimatedLength;
-                intersection.pathLength2 = path1EstimatedLength;
-            }
-        }];
-
         // save all of our intersections, we may need this reference
         // later if we filter out too many intersections as duplicates
         NSArray *allFoundIntersections = foundIntersections;
 
-        // iterate over the intersections and filter out duplicates
-        __block DKUIBezierPathIntersectionPoint *lastInter = [foundIntersections lastObject];
-        NSMutableSet<DKUIBezierPathIntersectionPoint *> *interToPrune = [NSMutableSet set];
-        foundIntersections = [NSMutableArray arrayWithArray:[foundIntersections filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^(id obj, NSDictionary *bindings) {
-            if (obj == lastInter) {
-                // we only have a single intersection
-                return YES;
-            }
-            DKUIBezierPathIntersectionPoint *intersection = obj;
-            BOOL isDistinctIntersection = ![obj matchesElementEndpointWithIntersection:lastInter];
-            CGPoint interLoc = intersection.location1;
-            CGPoint lastLoc = lastInter.location1;
-            CGPoint interLoc2 = intersection.location2;
-            CGPoint lastLoc2 = lastInter.location2;
-            if (isDistinctIntersection) {
-                if ((ABS(interLoc.x - lastLoc.x) < kUIBezierClosenessPrecision &&
-                     ABS(interLoc.y - lastLoc.y) < kUIBezierClosenessPrecision) ||
-                    (ABS(interLoc2.x - lastLoc2.x) < kUIBezierClosenessPrecision &&
-                     ABS(interLoc2.y - lastLoc2.y) < kUIBezierClosenessPrecision)) {
-                    // the points are close, but they might not necessarily be the same intersection.
-                    // for instance, a curve could be a very very very sharp V, and the intersection could
-                    // be slicing through the middle of the V to look like an ∀
-                    // the distance between the intersections along the - might be super small,
-                    // but along the V is much much further and should count as two intersections
-
-                    BOOL closeLocation1 = [lastInter isCloseToIntersection:intersection withPrecision:kUIBezierClosenessPrecision];
-                    BOOL closeLocation2 = [[lastInter flipped] isCloseToIntersection:[intersection flipped] withPrecision:kUIBezierClosenessPrecision];
-
-                    isDistinctIntersection = !closeLocation1 || !closeLocation2;
-                }
-            }
-
+        [foundIntersections enumerateObjectsUsingBlock:^(DKUIBezierPathIntersectionPoint *_Nonnull intersection, NSUInteger idx, BOOL *_Nonnull stop) {
             // Using the following tangents, determine if the intersection is entering or leaving the shape
             // or if the intersection is tangent to the shape.
             CGPoint shapeCGTan = [closedPath tangentOnPathAtElement:intersection.elementIndex2 andTValue:intersection.tValue2];
             CGPoint myCGTan = [self tangentOnPathAtElement:intersection.elementIndex1 andTValue:intersection.tValue1];
-
             DKVector *shapeTan = [DKVector vectorWithX:shapeCGTan.x andY:shapeCGTan.y];
             DKVector *myTan = [DKVector vectorWithX:myCGTan.x andY:myCGTan.y];
             CGFloat angle = [myTan angleWithRespectTo:shapeTan];
@@ -435,6 +392,39 @@ static NSInteger segmentCompareCount = 0;
                 } else {
                     // they disagree on right/left, so treat it as same
                     [intersection setDirection:kDKIntersectionDirectionSame];
+                }
+            }
+        }];
+
+        // iterate over the intersections and filter out duplicates
+        __block DKUIBezierPathIntersectionPoint *lastInter = [foundIntersections lastObject];
+        NSMutableSet<DKUIBezierPathIntersectionPoint *> *interToPrune = [NSMutableSet set];
+        foundIntersections = [NSMutableArray arrayWithArray:[foundIntersections filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^(id obj, NSDictionary *bindings) {
+            if (obj == lastInter) {
+                // we only have a single intersection
+                return YES;
+            }
+            DKUIBezierPathIntersectionPoint *intersection = obj;
+            BOOL isDistinctIntersection = ![obj matchesElementEndpointWithIntersection:lastInter];
+            CGPoint interLoc = intersection.location1;
+            CGPoint lastLoc = lastInter.location1;
+            CGPoint interLoc2 = intersection.location2;
+            CGPoint lastLoc2 = lastInter.location2;
+            if (isDistinctIntersection) {
+                if ((ABS(interLoc.x - lastLoc.x) < kUIBezierClosenessPrecision &&
+                     ABS(interLoc.y - lastLoc.y) < kUIBezierClosenessPrecision) ||
+                    (ABS(interLoc2.x - lastLoc2.x) < kUIBezierClosenessPrecision &&
+                     ABS(interLoc2.y - lastLoc2.y) < kUIBezierClosenessPrecision)) {
+                    // the points are close, but they might not necessarily be the same intersection.
+                    // for instance, a curve could be a very very very sharp V, and the intersection could
+                    // be slicing through the middle of the V to look like an ∀
+                    // the distance between the intersections along the - might be super small,
+                    // but along the V is much much further and should count as two intersections
+
+                    BOOL closeLocation1 = [lastInter isCloseToIntersection:intersection withPrecision:kUIBezierClosenessPrecision];
+                    BOOL closeLocation2 = [[lastInter flipped] isCloseToIntersection:[intersection flipped] withPrecision:kUIBezierClosenessPrecision];
+
+                    isDistinctIntersection = !closeLocation1 || !closeLocation2;
                 }
             }
 
@@ -615,11 +605,38 @@ static NSInteger segmentCompareCount = 0;
                     intersection.mayCrossBoundary = isInside != isInsideAfterIntersection;
                 }
 
-                // TODO: detect the direction that the intersection moves.
-
                 // setup for next iteration of loop
                 lastIntersection = intersection;
                 isInside = isInsideAfterIntersection;
+            }
+        }
+
+        for (int i = 1; i < [foundIntersections count]; i++) {
+            DKUIBezierPathIntersectionPoint *inter1 = foundIntersections[i - 1];
+            DKUIBezierPathIntersectionPoint *inter2 = foundIntersections[i];
+
+            if ([inter1 isCloseToIntersection:inter2 withPrecision:kUIBezierClosenessPrecision]) {
+                if (inter1.direction == kDKIntersectionDirectionSame && inter2.direction == kDKIntersectionDirectionSame) {
+                    [inter1.matchedIntersections addObjectsFromArray:[inter2.matchedIntersections allObjects]];
+                    [inter1.matchedIntersections addObject:inter2];
+                    [foundIntersections removeObjectAtIndex:i];
+                    i -= 1;
+                } else if (inter1.direction == kDKIntersectionDirectionSame) {
+                    [inter2.matchedIntersections addObjectsFromArray:[inter1.matchedIntersections allObjects]];
+                    [inter2.matchedIntersections addObject:inter1];
+                    [foundIntersections removeObjectAtIndex:i - 1];
+                    i -= 1;
+                } else if (inter2.direction == kDKIntersectionDirectionSame) {
+                    [inter1.matchedIntersections addObjectsFromArray:[inter2.matchedIntersections allObjects]];
+                    [inter1.matchedIntersections addObject:inter2];
+                    [foundIntersections removeObjectAtIndex:i];
+                    i -= 1;
+                } else if (inter1.direction == inter2.direction) {
+                    [inter1.matchedIntersections addObjectsFromArray:[inter2.matchedIntersections allObjects]];
+                    [inter1.matchedIntersections addObject:inter2];
+                    [foundIntersections removeObjectAtIndex:i];
+                    i -= 1;
+                }
             }
         }
 
@@ -1187,7 +1204,7 @@ static NSInteger segmentCompareCount = 0;
                                                                                              andLengthUntilPath1Loc:inter.lenAtInter1 + pathLengthForPreviousSubpaths
                                                                                              andLengthUntilPath2Loc:inter.lenAtInter2
                                                                                                      andPathLength1:scissorPath.length
-                                                                                                     andPathLength2:inter.pathLength2
+                                                                                                     andPathLength2:shapePath.length
                                                                                                      andClosedPath1:scissorPath.isClosed
                                                                                                      andClosedPath2:shapePath.isClosed];
         ret.bez1[0] = inter.bez1[0];
@@ -1395,7 +1412,7 @@ static NSInteger segmentCompareCount = 0;
     // because we're going to reuse and resort the tValuesOfIntersectionPoints1.
     // this solves rounding error that happens when intersections generate slightly differently
     // depending on the order of paths sent in
-    NSArray<DKUIBezierPathIntersectionPoint *> *intersectionsWithBoundaryInformation = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil];
+    NSMutableArray<DKUIBezierPathIntersectionPoint *> *intersectionsWithBoundaryInformation = [[shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil] mutableCopy];
     //
     // this array will be the intersections between the shape and the scissor.
     // we'll use the exact same intersection objects (flipped, b/c we're attacking from

--- a/ClippingBezier/UIBezierPath+Clipping.mm
+++ b/ClippingBezier/UIBezierPath+Clipping.mm
@@ -127,6 +127,8 @@ static NSInteger segmentCompareCount = 0;
     NSInteger elementCount1 = path1.elementCount;
     NSInteger elementCount2 = path2.elementCount;
 
+    CGFloat path1Length = path1.length;
+    CGFloat path2Length = path2.length;
 
     // track if the path1Element begins inside or
     // outside the closed path. this will help us track
@@ -247,7 +249,11 @@ static NSInteger segmentCompareCount = 0;
                                                                                                                         andElementCount1:elementCount1
                                                                                                                         andElementCount2:elementCount2
                                                                                                                   andLengthUntilPath1Loc:lenTillPath1Inter
-                                                                                                                  andLengthUntilPath2Loc:lenTillPath2Inter];
+                                                                                                                  andLengthUntilPath2Loc:lenTillPath2Inter
+                                                                                                                          andPathLength1:path1Length
+                                                                                                                          andPathLength2:path2Length
+                                                                                                                          andClosedPath1:path1.isClosed
+                                                                                                                          andClosedPath2:path2.isClosed];
                                     // store the two paths that the intersection relates to. these are
                                     // the paths that match each of the CGPathElements that we used to
                                     // find the intersection
@@ -753,8 +759,30 @@ static NSInteger segmentCompareCount = 0;
 
         } else {
             // it's closed or unclosed with 0 intersections
-            DKUIBezierUnmatchedPathIntersectionPoint *startOfBlue = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:0 andTValue:0 withElementIndex:NSNotFound andTValue:0 andElementCount1:self.elementCount andElementCount2:closedPath.elementCount andLengthUntilPath1Loc:self.length andLengthUntilPath2Loc:0];
-            DKUIBezierUnmatchedPathIntersectionPoint *endOfBlue = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:self.elementCount - 1 andTValue:1 withElementIndex:NSNotFound andTValue:0 andElementCount1:self.elementCount andElementCount2:closedPath.elementCount andLengthUntilPath1Loc:self.length andLengthUntilPath2Loc:0];
+            DKUIBezierUnmatchedPathIntersectionPoint *startOfBlue = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:0
+                                                                                                                               andTValue:0
+                                                                                                                        withElementIndex:NSNotFound
+                                                                                                                               andTValue:0
+                                                                                                                        andElementCount1:self.elementCount
+                                                                                                                        andElementCount2:closedPath.elementCount
+                                                                                                                  andLengthUntilPath1Loc:self.length
+                                                                                                                  andLengthUntilPath2Loc:0
+                                                                                                                          andPathLength1:self.length
+                                                                                                                          andPathLength2:closedPath.length
+                                                                                                                          andClosedPath1:self.isClosed
+                                                                                                                          andClosedPath2:closedPath.isClosed];
+            DKUIBezierUnmatchedPathIntersectionPoint *endOfBlue = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:self.elementCount - 1
+                                                                                                                             andTValue:1
+                                                                                                                      withElementIndex:NSNotFound
+                                                                                                                             andTValue:0
+                                                                                                                      andElementCount1:self.elementCount
+                                                                                                                      andElementCount2:closedPath.elementCount
+                                                                                                                andLengthUntilPath1Loc:self.length
+                                                                                                                andLengthUntilPath2Loc:0
+                                                                                                                        andPathLength1:self.length
+                                                                                                                        andPathLength2:closedPath.length
+                                                                                                                        andClosedPath1:self.isClosed
+                                                                                                                        andClosedPath2:closedPath.isClosed];
             NSArray *differenceSegments = [NSArray arrayWithObject:[DKUIBezierPathClippedSegment clippedPairWithStart:startOfBlue
                                                                                                                andEnd:endOfBlue
                                                                                                        andPathSegment:[self copy]
@@ -829,7 +857,18 @@ static NSInteger segmentCompareCount = 0;
     } else {
         // of unclosed paths, the "most recent" intersection is the non-intersection
         // of the start of the path. not sure why we're not using firstIntersectionIsStartOfPath
-        lastTValue = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:0 andTValue:0 withElementIndex:NSNotFound andTValue:0 andElementCount1:self.elementCount andElementCount2:closedPath.elementCount andLengthUntilPath1Loc:0 andLengthUntilPath2Loc:0];
+        lastTValue = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:0
+                                                                                andTValue:0
+                                                                         withElementIndex:NSNotFound
+                                                                                andTValue:0
+                                                                         andElementCount1:self.elementCount
+                                                                         andElementCount2:closedPath.elementCount
+                                                                   andLengthUntilPath1Loc:0
+                                                                   andLengthUntilPath2Loc:0
+                                                                           andPathLength1:self.length
+                                                                           andPathLength2:closedPath.length
+                                                                           andClosedPath1:self.isClosed
+                                                                           andClosedPath2:closedPath.isClosed];
     }
     if (firstTValue.elementIndex1 == 1 && firstTValue.tValue1 == 0) {
         // we start on an intersection, so use this as the "last"
@@ -840,7 +879,18 @@ static NSInteger segmentCompareCount = 0;
 
     // the last point is always the end of the path
 
-    DKUIBezierUnmatchedPathIntersectionPoint *endOfTheLine = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:self.elementCount - 1 andTValue:1 withElementIndex:NSNotFound andTValue:0 andElementCount1:self.elementCount andElementCount2:closedPath.elementCount andLengthUntilPath1Loc:self.length andLengthUntilPath2Loc:0];
+    DKUIBezierUnmatchedPathIntersectionPoint *endOfTheLine = [DKUIBezierUnmatchedPathIntersectionPoint intersectionAtElementIndex:self.elementCount - 1
+                                                                                                                        andTValue:1
+                                                                                                                 withElementIndex:NSNotFound
+                                                                                                                        andTValue:0
+                                                                                                                 andElementCount1:self.elementCount
+                                                                                                                 andElementCount2:closedPath.elementCount
+                                                                                                           andLengthUntilPath1Loc:self.length
+                                                                                                           andLengthUntilPath2Loc:0
+                                                                                                                   andPathLength1:self.length
+                                                                                                                   andPathLength2:closedPath.length
+                                                                                                                   andClosedPath1:self.isClosed
+                                                                                                                   andClosedPath2:closedPath.isClosed];
 
     CGPoint selfPathStartingPoint = self.firstPoint;
 
@@ -971,11 +1021,13 @@ static NSInteger segmentCompareCount = 0;
                                                                                                                andElementCount1:oldInter.elementIndex1
                                                                                                                andElementCount2:oldInter.elementIndex2
                                                                                                          andLengthUntilPath1Loc:oldInter.lenAtInter1
-                                                                                                         andLengthUntilPath2Loc:oldInter.lenAtInter2];
+                                                                                                         andLengthUntilPath2Loc:oldInter.lenAtInter2
+                                                                                                                 andPathLength1:oldInter.pathLength1
+                                                                                                                 andPathLength2:oldInter.pathLength2
+                                                                                                                 andClosedPath1:oldInter.pathClosed1
+                                                                                                                 andClosedPath2:oldInter.pathClosed2];
                         [newInter setMayCrossBoundary:oldInter.mayCrossBoundary];
                         [newInter setDirection:oldInter.direction];
-                        newInter.pathLength1 = oldInter.pathLength1;
-                        newInter.pathLength2 = oldInter.pathLength2;
                         [tValuesOfIntersectionPoints replaceObjectAtIndex:i withObject:newInter];
                     }
                 }
@@ -1133,7 +1185,11 @@ static NSInteger segmentCompareCount = 0;
                                                                                                    andElementCount1:[scissorPath elementCount]
                                                                                                    andElementCount2:inter.elementCount2
                                                                                              andLengthUntilPath1Loc:inter.lenAtInter1 + pathLengthForPreviousSubpaths
-                                                                                             andLengthUntilPath2Loc:inter.lenAtInter2];
+                                                                                             andLengthUntilPath2Loc:inter.lenAtInter2
+                                                                                                     andPathLength1:scissorPath.length
+                                                                                                     andPathLength2:inter.pathLength2
+                                                                                                     andClosedPath1:scissorPath.isClosed
+                                                                                                     andClosedPath2:shapePath.isClosed];
         ret.bez1[0] = inter.bez1[0];
         ret.bez1[1] = inter.bez1[1];
         ret.bez1[2] = inter.bez1[2];
@@ -1143,8 +1199,6 @@ static NSInteger segmentCompareCount = 0;
         ret.bez2[2] = inter.bez2[2];
         ret.bez2[3] = inter.bez2[3];
         ret.mayCrossBoundary = inter.mayCrossBoundary;
-        ret.pathLength1 = [scissorPath length];
-        ret.pathLength2 = inter.pathLength2;
         return ret;
     };
     DKUIBezierPathClippedSegment * (^adjustNonIntersectionPointForSegment)(DKUIBezierPathClippedSegment *) =
@@ -1679,14 +1733,58 @@ static NSInteger segmentCompareCount = 0;
     if (![intersections count]) {
         // there are no intersections between the paths, which means one fully encompasses the other, or
         // they are completely outside each other
-        DKUIBezierPathIntersectionPoint *start1 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:0 andTValue:0 withElementIndex:-1 andTValue:-1 andElementCount1:self.elementCount andElementCount2:scissors.elementCount andLengthUntilPath1Loc:0 andLengthUntilPath2Loc:-1];
-        DKUIBezierPathIntersectionPoint *end1 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:self.elementCount - 1 andTValue:1 withElementIndex:-1 andTValue:-1 andElementCount1:self.elementCount andElementCount2:scissors.elementCount andLengthUntilPath1Loc:0 andLengthUntilPath2Loc:-1];
+        DKUIBezierPathIntersectionPoint *start1 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:0
+                                                                                                    andTValue:0
+                                                                                             withElementIndex:-1
+                                                                                                    andTValue:-1
+                                                                                             andElementCount1:self.elementCount
+                                                                                             andElementCount2:scissors.elementCount
+                                                                                       andLengthUntilPath1Loc:0
+                                                                                       andLengthUntilPath2Loc:-1
+                                                                                               andPathLength1:self.length
+                                                                                               andPathLength2:scissors.length
+                                                                                               andClosedPath1:self.isClosed
+                                                                                               andClosedPath2:scissors.isClosed];
+        DKUIBezierPathIntersectionPoint *end1 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:self.elementCount - 1
+                                                                                                  andTValue:1
+                                                                                           withElementIndex:-1
+                                                                                                  andTValue:-1
+                                                                                           andElementCount1:self.elementCount
+                                                                                           andElementCount2:scissors.elementCount
+                                                                                     andLengthUntilPath1Loc:0
+                                                                                     andLengthUntilPath2Loc:-1
+                                                                                             andPathLength1:self.length
+                                                                                             andPathLength2:scissors.length
+                                                                                             andClosedPath1:self.isClosed
+                                                                                             andClosedPath2:scissors.isClosed];
         DKUIBezierPathClippedSegment *segment1 = [DKUIBezierPathClippedSegment clippedPairWithStart:start1 andEnd:end1 andPathSegment:[self copy] fromFullPath:self];
         DKUIBezierPathShape *shape1 = [[DKUIBezierPathShape alloc] init];
         [shape1.segments addObject:segment1];
 
-        DKUIBezierPathIntersectionPoint *start2 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:0 andTValue:0 withElementIndex:-1 andTValue:-1 andElementCount1:scissors.elementCount andElementCount2:self.elementCount andLengthUntilPath1Loc:0 andLengthUntilPath2Loc:-1];
-        DKUIBezierPathIntersectionPoint *end2 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:scissors.elementCount - 1 andTValue:1 withElementIndex:-1 andTValue:-1 andElementCount1:scissors.elementCount andElementCount2:self.elementCount andLengthUntilPath1Loc:0 andLengthUntilPath2Loc:-1];
+        DKUIBezierPathIntersectionPoint *start2 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:0
+                                                                                                    andTValue:0
+                                                                                             withElementIndex:-1
+                                                                                                    andTValue:-1
+                                                                                             andElementCount1:scissors.elementCount
+                                                                                             andElementCount2:self.elementCount
+                                                                                       andLengthUntilPath1Loc:0
+                                                                                       andLengthUntilPath2Loc:-1
+                                                                                               andPathLength1:scissors.length
+                                                                                               andPathLength2:self.length
+                                                                                               andClosedPath1:scissors.isClosed
+                                                                                               andClosedPath2:self.isClosed];
+        DKUIBezierPathIntersectionPoint *end2 = [DKUIBezierPathIntersectionPoint intersectionAtElementIndex:scissors.elementCount - 1
+                                                                                                  andTValue:1
+                                                                                           withElementIndex:-1
+                                                                                                  andTValue:-1
+                                                                                           andElementCount1:scissors.elementCount
+                                                                                           andElementCount2:self.elementCount
+                                                                                     andLengthUntilPath1Loc:0
+                                                                                     andLengthUntilPath2Loc:-1
+                                                                                             andPathLength1:scissors.length
+                                                                                             andPathLength2:self.length
+                                                                                             andClosedPath1:scissors.isClosed
+                                                                                             andClosedPath2:self.isClosed];
         DKUIBezierPathClippedSegment *segment2 = [DKUIBezierPathClippedSegment clippedPairWithStart:start2 andEnd:end2 andPathSegment:[scissors copy] fromFullPath:scissors];
         DKUIBezierPathShape *shape2 = [[DKUIBezierPathShape alloc] init];
         [shape2.segments addObject:segment2];

--- a/ClippingBezierTests/MMClippingBezierIntersectionDirectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionDirectionTests.m
@@ -35,6 +35,10 @@
     return thetaAB;
 }
 
+#pragma mark - Direction tests
+// In the following tests, we are curious about the relationship of v with respect to x.
+// The x vector is our reference vector
+
 /// Vector v is pointing to the right of x
 - (void)testIntersectionDirection1
 {
@@ -49,11 +53,24 @@
     XCTAssertGreaterThan(theta, 0);
 }
 
+/// Vector v is pointing to the right of x
+/// same as `testIntersectionDirection1` using `DKVector` class
+- (void)testIntersectionDirection1vector
+{
+    DKVector *x = [DKVector vectorWithX:1 andY:1];
+    DKVector *v = [DKVector vectorWithX:2 andY:1];
+    DKVector *proj = [x projectedOnto:v];
+    DKVector *n = [x add:[proj flip]];
+    CGFloat theta = [x angleWithRespectTo:n];
+
+    XCTAssertGreaterThan(theta, 0);
+}
+
 /// Vector v is pointing to the left of x
 - (void)testIntersectionDirection2
 {
-    CGVector v = CGVectorMake(1, 2);
     CGVector x = CGVectorMake(1, 1);
+    CGVector v = CGVectorMake(1, 2);
     CGFloat dp = v.dx * x.dx + v.dy * x.dy;
     CGFloat vv = v.dx * v.dx + v.dy * v.dy;
     CGFloat c = dp / vv;
@@ -66,8 +83,8 @@
 /// Vector v and x are pointing in the same direction
 - (void)testIntersectionDirection3
 {
-    CGVector v = CGVectorMake(1, 1);
     CGVector x = CGVectorMake(1, 1);
+    CGVector v = CGVectorMake(1, 1);
     CGFloat dp = v.dx * x.dx + v.dy * x.dy;
     CGFloat vv = v.dx * v.dx + v.dy * v.dy;
     CGFloat c = dp / vv;
@@ -84,8 +101,8 @@
 /// Vector v and x are pointing in opposite directions
 - (void)testIntersectionDirection4
 {
-    CGVector v = CGVectorMake(-1, -1);
     CGVector x = CGVectorMake(1, 1);
+    CGVector v = CGVectorMake(-1, -1);
     CGFloat dp = v.dx * x.dx + v.dy * x.dy;
     CGFloat vv = v.dx * v.dx + v.dy * v.dy;
     CGFloat c = dp / vv;
@@ -97,6 +114,25 @@
     CGFloat theta = [self angleBetween:x and:v];
 
     XCTAssertEqualWithAccuracy(theta, -M_PI, 0.000001);
+}
+
+//        +-------+
+//        |       |
+//    +------->   |
+//        |       |
+//        +-------+
+- (void)testLineIntoSquare
+{
+    UIBezierPath *scissorPath = [UIBezierPath bezierPath];
+    [scissorPath moveToPoint:CGPointMake(-50, 50)];
+    [scissorPath addLineToPoint:CGPointMake(250, 50)];
+
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(0, 0, 100, 100)];
+
+    NSArray<DKUIBezierPathIntersectionPoint *> *intersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:nil];
+
+    XCTAssertEqual([[intersections objectAtIndex:0] direction], kDKIntersectionDirectionRight);
+    XCTAssertEqual([[intersections objectAtIndex:1] direction], kDKIntersectionDirectionLeft);
 }
 
 @end

--- a/ClippingBezierTests/MMClippingBezierIntersectionDirectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionDirectionTests.m
@@ -1,0 +1,102 @@
+//
+//  MMClippingBezierIntersectionDirectionTests.m
+//  ClippingBezierTests
+//
+//  Created by Adam Wulf on 11/11/20.
+//
+
+#import <XCTest/XCTest.h>
+#import "MMClippingBezierAbstractTest.h"
+
+@interface MMClippingBezierIntersectionDirectionTests : MMClippingBezierAbstractTest
+
+@end
+
+@implementation MMClippingBezierIntersectionDirectionTests
+
+- (CGFloat)angleBetween:(CGVector)v1 and:(CGVector)v2
+{
+    if ((v1.dx == 0 && v1.dy == 0) || (v2.dx == 0 && v2.dy == 0)) {
+        XCTFail("must be non-zero vector");
+    }
+    // angle with +ve x-axis, in the range (−π, π]
+    float thetaA = atan2(v2.dx, v2.dy);
+    float thetaB = atan2(v1.dx, v1.dy);
+
+    float thetaAB = thetaB - thetaA;
+
+    // get in range (−π, π]
+    while (thetaAB <= -M_PI)
+        thetaAB += 2 * M_PI;
+
+    while (thetaAB > M_PI)
+        thetaAB -= 2 * M_PI;
+
+    return thetaAB;
+}
+
+/// Vector v is pointing to the right of x
+- (void)testIntersectionDirection1
+{
+    CGVector v = CGVectorMake(2, 1);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+    CGFloat theta = [self angleBetween:x and:n];
+
+    XCTAssertGreaterThan(theta, 0);
+}
+
+/// Vector v is pointing to the left of x
+- (void)testIntersectionDirection2
+{
+    CGVector v = CGVectorMake(1, 2);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+    CGFloat theta = [self angleBetween:x and:n];
+
+    XCTAssertLessThan(theta, 0);
+}
+
+/// Vector v and x are pointing in the same direction
+- (void)testIntersectionDirection3
+{
+    CGVector v = CGVectorMake(1, 1);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+
+    XCTAssertEqual(n.dx, 0);
+    XCTAssertEqual(n.dy, 0);
+
+    CGFloat theta = [self angleBetween:x and:v];
+
+    XCTAssertEqual(theta, 0);
+}
+
+/// Vector v and x are pointing in opposite directions
+- (void)testIntersectionDirection4
+{
+    CGVector v = CGVectorMake(-1, -1);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+
+    XCTAssertEqual(n.dx, 0);
+    XCTAssertEqual(n.dy, 0);
+
+    CGFloat theta = [self angleBetween:x and:v];
+
+    XCTAssertEqualWithAccuracy(theta, -M_PI, 0.000001);
+}
+
+@end

--- a/ClippingBezierTests/MMClippingBezierIntersectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionTests.m
@@ -677,13 +677,13 @@
     XCTAssertEqual([self round:[[intersections objectAtIndex:1] tValue2] to:6], 0.0, @"found correct intersection location");
 
     XCTAssertEqual([[otherIntersections objectAtIndex:0] elementIndex1], 1, @"found correct intersection location");
-    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue1] to:6], (CGFloat)1.0, @"found correct intersection location");
-    XCTAssertEqual([[otherIntersections objectAtIndex:1] elementIndex1], 2, @"found correct intersection location");
+    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue1] to:6], (CGFloat)0, @"found correct intersection location");
+    XCTAssertEqual([[otherIntersections objectAtIndex:1] elementIndex1], 1, @"found correct intersection location");
     XCTAssertEqual([self round:[[otherIntersections objectAtIndex:1] tValue1] to:6], (CGFloat)1.0, @"found correct intersection location");
     XCTAssertEqual([[otherIntersections objectAtIndex:0] elementIndex2], 1, @"found correct intersection location");
-    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue2] to:6], (CGFloat)0.7, @"found correct intersection location");
+    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue2] to:6], (CGFloat)0.1, @"found correct intersection location");
     XCTAssertEqual([[otherIntersections objectAtIndex:1] elementIndex2], 1, @"found correct intersection location");
-    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:1] tValue2] to:6], (CGFloat)0.1, @"found correct intersection location");
+    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:1] tValue2] to:6], (CGFloat)0.7, @"found correct intersection location");
 
     XCTAssertTrue([[intersections objectAtIndex:0] mayCrossBoundary], @"crosses boundary");
     XCTAssertTrue([[intersections objectAtIndex:1] mayCrossBoundary], @"crosses boundary");
@@ -1058,8 +1058,8 @@
     NSArray *intersections1 = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil];
     NSArray *intersections2 = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:nil];
 
-    XCTAssertEqual([intersections1 count], (NSUInteger)5, @"5 intersections so we can check for the tangent case");
-    XCTAssertEqual([intersections2 count], (NSUInteger)5, @"5 intersections so we can check for the tangent case");
+    XCTAssertEqual([intersections1 count], (NSUInteger)6, @"5 intersections so we can check for the tangent case");
+    XCTAssertEqual([intersections2 count], (NSUInteger)6, @"5 intersections so we can check for the tangent case");
 }
 
 - (void)testLineThroughNearTangent
@@ -1097,8 +1097,8 @@
     NSArray *intersections1 = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil];
     NSArray *intersections2 = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:nil];
 
-    XCTAssertEqual([intersections1 count], (NSUInteger)3, @"intersections so we can check for the tangent case");
-    XCTAssertEqual([intersections2 count], (NSUInteger)3, @"intersections so we can check for the tangent case");
+    XCTAssertEqual([intersections1 count], (NSUInteger)4, @"intersections so we can check for the tangent case");
+    XCTAssertEqual([intersections2 count], (NSUInteger)4, @"intersections so we can check for the tangent case");
 }
 
 - (void)testShapeWithLoop
@@ -1200,8 +1200,8 @@
     NSArray *intersections1 = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:nil];
     NSArray *intersections2 = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:nil];
 
-    XCTAssertEqual([intersections1 count], (NSUInteger)3, @"intersections so we can check for the tangent case");
-    XCTAssertEqual([intersections2 count], (NSUInteger)3, @"intersections so we can check for the tangent case");
+    XCTAssertEqual([intersections1 count], (NSUInteger)4, @"intersections so we can check for the tangent case");
+    XCTAssertEqual([intersections2 count], (NSUInteger)4, @"intersections so we can check for the tangent case");
 }
 
 - (void)testScissorsCreatingHole

--- a/ClippingBezierTests/MMClippingBezierIntersectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionTests.m
@@ -1300,4 +1300,33 @@
     XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)6, @"count of intersections matches");
 }
 
+- (void)testCircleThroughReversedRectangleFirstSegmentTangent
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+    shapePath = [shapePath bezierPathByReversingPath];
+    BOOL beginsInside = NO;
+    NSArray *scissorToShapeIntersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:&beginsInside];
+    NSArray *shapeToScissorIntersections = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:&beginsInside];
+
+    XCTAssertEqual([scissorToShapeIntersections count], [shapeToScissorIntersections count], @"count of intersections matches");
+    XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)6, @"count of intersections matches");
+}
+
+- (void)testCircleThroughReversedRectangleFirstSegmentTangent2
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+    BOOL beginsInside = NO;
+    NSArray *scissorToShapeIntersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:&beginsInside];
+    NSArray *shapeToScissorIntersections = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:&beginsInside];
+
+    XCTAssertEqual([scissorToShapeIntersections count], [shapeToScissorIntersections count], @"count of intersections matches");
+    XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)6, @"count of intersections matches");
+}
+
 @end

--- a/ClippingBezierTests/MMClippingBezierIntersectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionTests.m
@@ -18,103 +18,6 @@
 
 @implementation MMClippingBezierIntersectionTests
 
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here; it will be run once, before the first test case.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here; it will be run once, after the last test case.
-    [super tearDown];
-}
-
-- (CGFloat)angleBetween:(CGVector)v1 and:(CGVector)v2
-{
-    if ((v1.dx == 0 && v1.dy == 0) || (v2.dx == 0 && v2.dy == 0)) {
-        XCTFail("must be non-zero vector");
-    }
-    // angle with +ve x-axis, in the range (−π, π]
-    float thetaA = atan2(v2.dx, v2.dy);
-    float thetaB = atan2(v1.dx, v1.dy);
-
-    float thetaAB = thetaB - thetaA;
-
-    // get in range (−π, π]
-    while (thetaAB <= -M_PI)
-        thetaAB += 2 * M_PI;
-
-    while (thetaAB > M_PI)
-        thetaAB -= 2 * M_PI;
-
-    return thetaAB;
-}
-
-/// Vector v is pointing to the right of x
-- (void)testIntersectionDirection1
-{
-    CGVector v = CGVectorMake(2, 1);
-    CGVector x = CGVectorMake(1, 1);
-    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
-    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
-    CGFloat c = dp / vv;
-    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
-    CGFloat theta = [self angleBetween:x and:n];
-
-    XCTAssertGreaterThan(theta, 0);
-}
-
-/// Vector v is pointing to the left of x
-- (void)testIntersectionDirection2
-{
-    CGVector v = CGVectorMake(1, 2);
-    CGVector x = CGVectorMake(1, 1);
-    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
-    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
-    CGFloat c = dp / vv;
-    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
-    CGFloat theta = [self angleBetween:x and:n];
-
-    XCTAssertLessThan(theta, 0);
-}
-
-/// Vector v and x are pointing in the same direction
-- (void)testIntersectionDirection3
-{
-    CGVector v = CGVectorMake(1, 1);
-    CGVector x = CGVectorMake(1, 1);
-    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
-    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
-    CGFloat c = dp / vv;
-    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
-
-    XCTAssertEqual(n.dx, 0);
-    XCTAssertEqual(n.dy, 0);
-
-    CGFloat theta = [self angleBetween:x and:v];
-
-    XCTAssertEqual(theta, 0);
-}
-
-/// Vector v and x are pointing in opposite directions
-- (void)testIntersectionDirection4
-{
-    CGVector v = CGVectorMake(-1, -1);
-    CGVector x = CGVectorMake(1, 1);
-    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
-    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
-    CGFloat c = dp / vv;
-    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
-
-    XCTAssertEqual(n.dx, 0);
-    XCTAssertEqual(n.dy, 0);
-
-    CGFloat theta = [self angleBetween:x and:v];
-
-    XCTAssertEqualWithAccuracy(theta, -M_PI, 0.000001);
-}
-
 - (void)testIntersectionByClipping
 {
     //
@@ -1133,6 +1036,9 @@
 
 - (void)testSquaredCircleIntersections
 {
+    // there is a TODO in UIBezierPath+Clipping.m to handle tangent lines
+    XCTAssertTrue(NO, @"functionality needs defining");
+
     UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 200)];
     UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
     NSArray *intersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:nil];

--- a/ClippingBezierTests/MMClippingBezierIntersectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionTests.m
@@ -677,13 +677,13 @@
     XCTAssertEqual([self round:[[intersections objectAtIndex:1] tValue2] to:6], 0.0, @"found correct intersection location");
 
     XCTAssertEqual([[otherIntersections objectAtIndex:0] elementIndex1], 1, @"found correct intersection location");
-    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue1] to:6], (CGFloat)0, @"found correct intersection location");
-    XCTAssertEqual([[otherIntersections objectAtIndex:1] elementIndex1], 1, @"found correct intersection location");
+    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue1] to:6], (CGFloat)1.0, @"found correct intersection location");
+    XCTAssertEqual([[otherIntersections objectAtIndex:1] elementIndex1], 2, @"found correct intersection location");
     XCTAssertEqual([self round:[[otherIntersections objectAtIndex:1] tValue1] to:6], (CGFloat)1.0, @"found correct intersection location");
     XCTAssertEqual([[otherIntersections objectAtIndex:0] elementIndex2], 1, @"found correct intersection location");
-    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue2] to:6], (CGFloat)0.1, @"found correct intersection location");
+    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:0] tValue2] to:6], (CGFloat)0.7, @"found correct intersection location");
     XCTAssertEqual([[otherIntersections objectAtIndex:1] elementIndex2], 1, @"found correct intersection location");
-    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:1] tValue2] to:6], (CGFloat)0.7, @"found correct intersection location");
+    XCTAssertEqual([self round:[[otherIntersections objectAtIndex:1] tValue2] to:6], (CGFloat)0.1, @"found correct intersection location");
 
     XCTAssertTrue([[intersections objectAtIndex:0] mayCrossBoundary], @"crosses boundary");
     XCTAssertTrue([[intersections objectAtIndex:1] mayCrossBoundary], @"crosses boundary");
@@ -1276,13 +1276,28 @@
     [scissorPath moveToPoint:CGPointMake(493.500000, 1024.000000)];
     [scissorPath addCurveToPoint:CGPointMake(495.500000, 1024.000000) controlPoint1:CGPointMake(494.250000, 1024.000000) controlPoint2:CGPointMake(494.750000, 1024.000000)];
 
-
     BOOL beginsInside = NO;
     NSArray *scissorToShapeIntersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:&beginsInside];
     NSArray *shapeToScissorIntersections = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:&beginsInside];
 
     XCTAssertEqual([scissorToShapeIntersections count], [shapeToScissorIntersections count], @"count of intersections matches");
     XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)2, @"count of intersections matches");
+}
+
+- (void)testCircleThroughReversedRectangle
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+    shapePath = [shapePath bezierPathByReversingPath];
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+
+    BOOL beginsInside = NO;
+    NSArray *scissorToShapeIntersections = [scissorPath findIntersectionsWithClosedPath:shapePath andBeginsInside:&beginsInside];
+    NSArray *shapeToScissorIntersections = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:&beginsInside];
+
+    XCTAssertEqual([scissorToShapeIntersections count], [shapeToScissorIntersections count], @"count of intersections matches");
+    XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)6, @"count of intersections matches");
 }
 
 @end

--- a/ClippingBezierTests/MMClippingBezierIntersectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionTests.m
@@ -1326,7 +1326,7 @@
     NSArray *shapeToScissorIntersections = [shapePath findIntersectionsWithClosedPath:scissorPath andBeginsInside:&beginsInside];
 
     XCTAssertEqual([scissorToShapeIntersections count], [shapeToScissorIntersections count], @"count of intersections matches");
-    XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)6, @"count of intersections matches");
+    XCTAssertEqual([scissorToShapeIntersections count], (NSUInteger)3, @"count of intersections matches");
 }
 
 @end

--- a/ClippingBezierTests/MMClippingBezierIntersectionTests.m
+++ b/ClippingBezierTests/MMClippingBezierIntersectionTests.m
@@ -30,6 +30,91 @@
     [super tearDown];
 }
 
+- (CGFloat)angleBetween:(CGVector)v1 and:(CGVector)v2
+{
+    if ((v1.dx == 0 && v1.dy == 0) || (v2.dx == 0 && v2.dy == 0)) {
+        XCTFail("must be non-zero vector");
+    }
+    // angle with +ve x-axis, in the range (−π, π]
+    float thetaA = atan2(v2.dx, v2.dy);
+    float thetaB = atan2(v1.dx, v1.dy);
+
+    float thetaAB = thetaB - thetaA;
+
+    // get in range (−π, π]
+    while (thetaAB <= -M_PI)
+        thetaAB += 2 * M_PI;
+
+    while (thetaAB > M_PI)
+        thetaAB -= 2 * M_PI;
+
+    return thetaAB;
+}
+
+/// Vector v is pointing to the right of x
+- (void)testIntersectionDirection1
+{
+    CGVector v = CGVectorMake(2, 1);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+    CGFloat theta = [self angleBetween:x and:n];
+
+    XCTAssertGreaterThan(theta, 0);
+}
+
+/// Vector v is pointing to the left of x
+- (void)testIntersectionDirection2
+{
+    CGVector v = CGVectorMake(1, 2);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+    CGFloat theta = [self angleBetween:x and:n];
+
+    XCTAssertLessThan(theta, 0);
+}
+
+/// Vector v and x are pointing in the same direction
+- (void)testIntersectionDirection3
+{
+    CGVector v = CGVectorMake(1, 1);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+
+    XCTAssertEqual(n.dx, 0);
+    XCTAssertEqual(n.dy, 0);
+
+    CGFloat theta = [self angleBetween:x and:v];
+
+    XCTAssertEqual(theta, 0);
+}
+
+/// Vector v and x are pointing in opposite directions
+- (void)testIntersectionDirection4
+{
+    CGVector v = CGVectorMake(-1, -1);
+    CGVector x = CGVectorMake(1, 1);
+    CGFloat dp = v.dx * x.dx + v.dy * x.dy;
+    CGFloat vv = v.dx * v.dx + v.dy * v.dy;
+    CGFloat c = dp / vv;
+    CGVector n = CGVectorMake(x.dx - c * v.dx, x.dy - c * v.dy);
+
+    XCTAssertEqual(n.dx, 0);
+    XCTAssertEqual(n.dy, 0);
+
+    CGFloat theta = [self angleBetween:x and:v];
+
+    XCTAssertEqualWithAccuracy(theta, -M_PI, 0.000001);
+}
+
 - (void)testIntersectionByClipping
 {
     //

--- a/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
@@ -801,6 +801,9 @@
 
 - (void)testCircleThroughRectangle
 {
+    // there is a TODO in UIBezierPath+Clipping.m to handle tangent lines
+    XCTAssertTrue(NO, @"functionality needs defining");
+
     // here, the scissor is a circle that is contained with in a square shape
     // the square wraps around the outside of the circle
     UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];

--- a/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
@@ -1272,9 +1272,9 @@
     NSArray *greenSegments = [redGreenBlueSegs objectAtIndex:1];
     NSArray *blueSegments = [redGreenBlueSegs lastObject];
 
-    XCTAssertEqual([redSegments count], (NSUInteger)2, @"correct number of segments");
+    XCTAssertEqual([redSegments count], (NSUInteger)3, @"correct number of segments");
     XCTAssertEqual([greenSegments count], (NSUInteger)2, @"correct number of segments");
-    XCTAssertEqual([blueSegments count], (NSUInteger)3, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)4, @"correct number of segments");
 
 
     DKUIBezierPathClippedSegment *redSegment = [redSegments firstObject];

--- a/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
@@ -56,7 +56,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -88,7 +88,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -129,7 +129,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -154,7 +154,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -184,7 +184,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -216,7 +216,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -251,7 +251,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -295,7 +295,7 @@
                                                                                                  andBlue:blueSegments
                                                                                               lastWasRed:YES
                                                                                                     comp:[shapePath isClockwise]];
-    XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+    XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
 
 
     //
@@ -312,7 +312,7 @@
                                                                    andBlue:blueSegments
                                                                 lastWasRed:YES
                                                                       comp:[shapePath isClockwise]];
-    XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+    XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
 }
 
 - (void)testIntersectionSplittingLineElement
@@ -343,7 +343,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -367,7 +367,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -388,7 +388,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -409,7 +409,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -430,7 +430,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -451,7 +451,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -488,7 +488,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -528,7 +528,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -568,7 +568,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
     }
 }
 
@@ -610,7 +610,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 
     // but the reverse scissor, since it's tangent to the shape, will end up taking left turns.
@@ -620,7 +620,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is right turn");
     }
 }
 
@@ -660,7 +660,7 @@
                                                                                                  andBlue:blueSegments
                                                                                               lastWasRed:YES
                                                                                                     comp:[shapePath isClockwise]];
-    XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+    XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
 }
 
 - (void)testLineThroughOval
@@ -689,7 +689,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -720,7 +720,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -757,7 +757,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -795,7 +795,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -822,7 +822,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -847,7 +847,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -873,7 +873,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
     }
 }
 
@@ -907,7 +907,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -933,7 +933,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -976,7 +976,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
     }
     for (DKUIBezierPathClippedSegment *redSegment in [redSegments subarrayWithRange:NSMakeRange(6, 2)]) {
         DKUIBezierPathClippedSegment *currentSegmentCandidate = [UIBezierPath getBestMatchSegmentForSegments:[NSArray arrayWithObject:redSegment]
@@ -984,7 +984,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
     }
 
     // left turn is all that's available for this one...
@@ -994,7 +994,7 @@
                                                                                                  andBlue:blueSegments
                                                                                               lastWasRed:YES
                                                                                                     comp:[shapePath isClockwise]];
-    XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+    XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
 }
 
 - (void)testSingleExternalTangents
@@ -1034,7 +1034,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] >= 0, @"angle is right turn");
     }
 }
 
@@ -1086,7 +1086,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -1145,7 +1145,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] < 0, @"angle is left turn");
     }
 }
 
@@ -1172,7 +1172,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -1200,7 +1200,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -1224,7 +1224,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -1250,7 +1250,7 @@
                                                                                                      andBlue:blueSegments
                                                                                                   lastWasRed:YES
                                                                                                         comp:[shapePath isClockwise]];
-        XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     }
 }
 
@@ -1287,7 +1287,7 @@
                                                                                                  andBlue:blueSegments
                                                                                               lastWasRed:YES
                                                                                                     comp:[shapePath isClockwise]];
-    XCTAssertTrue([redSegment.endVector angleBetween:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+    XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
     XCTAssertTrue([blueSegments containsObject:currentSegmentCandidate], @"best match is blue");
 }
 

--- a/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTangentTests.m
@@ -1318,4 +1318,51 @@
     XCTAssertEqual([blueSegments count], (NSUInteger)2, @"correct number of segments");
 }
 
+- (void)testCircleThroughRectangleFirstSegmentTangent2
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+
+    XCTAssertTrue([shapePath isClockwise], @"shape is clockwise");
+
+    NSArray *allSegments = [UIBezierPath redAndBlueSegmentsForShapeBuildingCreatedFrom:shapePath bySlicingWithPath:scissorPath andNumberOfBlueShellSegments:nil];
+    NSArray *redSegments = [allSegments firstObject];
+    NSArray *blueSegments = [allSegments lastObject];
+
+    for (DKUIBezierPathClippedSegment *redSegment in redSegments) {
+        DKUIBezierPathClippedSegment *currentSegmentCandidate = [UIBezierPath getBestMatchSegmentForSegments:[NSArray arrayWithObject:redSegment]
+                                                                                                      forRed:redSegments
+                                                                                                     andBlue:blueSegments
+                                                                                                  lastWasRed:YES
+                                                                                                        comp:[shapePath isClockwise]];
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+    }
+}
+
+- (void)testCircleThroughRectangleCompareTangents2
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+
+    XCTAssertTrue([shapePath isClockwise], @"shape is correct direction");
+
+    NSArray *redBlueSegs = [UIBezierPath redAndBlueSegmentsForShapeBuildingCreatedFrom:shapePath bySlicingWithPath:scissorPath andNumberOfBlueShellSegments:nil];
+    NSArray *redSegments = [redBlueSegs firstObject];
+    NSArray *blueSegments = [redBlueSegs lastObject];
+
+    // the forward path takes right turns, like normal...
+    for (DKUIBezierPathClippedSegment *redSegment in redSegments) {
+        DKUIBezierPathClippedSegment *currentSegmentCandidate = [UIBezierPath getBestMatchSegmentForSegments:[NSArray arrayWithObject:redSegment]
+                                                                                                      forRed:redSegments
+                                                                                                     andBlue:blueSegments
+                                                                                                  lastWasRed:YES
+                                                                                                        comp:[shapePath isClockwise]];
+        XCTAssertTrue([redSegment.endVector angleWithRespectTo:currentSegmentCandidate.startVector] > 0, @"angle is right turn");
+    }
+}
+
 @end

--- a/ClippingBezierTests/MMClippingBezierSegmentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTests.m
@@ -262,8 +262,8 @@
                                                                                                     comp:[shapePath isClockwise]];
     XCTAssertTrue(currentSegmentCandidate == correctSegment, @"found correct segment");
 
-    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 1, @"correct intersection");
-    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)1.0, @"correct intersection");
+    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 2, @"correct intersection");
+    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)0, @"correct intersection");
     XCTAssertEqual(redSegment.endIntersection.elementIndex1, 4, @"correct intersection");
     XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], (CGFloat)0.170317, @"correct intersection");
 
@@ -474,8 +474,8 @@
                                                                                                     comp:[shapePath isClockwise]];
     XCTAssertTrue(currentSegmentCandidate == correctSegment, @"found correct segment");
 
-    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 1, @"correct intersection");
-    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)0.0, @"correct intersection");
+    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 5, @"correct intersection");
+    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)1.0, @"correct intersection");
     XCTAssertEqual(redSegment.endIntersection.elementIndex1, 1, @"correct intersection");
     XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], (CGFloat)0.45, @"correct intersection");
 
@@ -525,8 +525,8 @@
                                                                                                     comp:[shapePath isClockwise]];
     XCTAssertTrue(currentSegmentCandidate == correctSegment, @"found correct segment");
 
-    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 1, @"correct intersection");
-    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)0.0, @"correct intersection");
+    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 5, @"correct intersection");
+    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)1.0, @"correct intersection");
     XCTAssertEqual(redSegment.endIntersection.elementIndex1, 1, @"correct intersection");
     XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], (CGFloat)0.45, @"correct intersection");
 
@@ -1243,8 +1243,8 @@
     NSArray *redSegments = [redBlueSegs firstObject];
     NSArray *blueSegments = [redBlueSegs lastObject];
 
-    XCTAssertEqual([redSegments count], (NSUInteger)2, @"the curves do intersect");
-    XCTAssertEqual([blueSegments count], (NSUInteger)2, @"the curves do intersect");
+    XCTAssertEqual([redSegments count], (NSUInteger)4, @"the curves do intersect");
+    XCTAssertEqual([blueSegments count], (NSUInteger)4, @"the curves do intersect");
 
     DKUIBezierPathClippedSegment *redSegment = [redSegments objectAtIndex:0];
     DKUIBezierPathClippedSegment *correctSegment = [blueSegments objectAtIndex:0];
@@ -1999,9 +1999,9 @@
     NSArray *greenSegments = [redGreenBlueSegs objectAtIndex:1];
     NSArray *blueSegments = [redGreenBlueSegs lastObject];
 
-    XCTAssertEqual([redSegments count], (NSUInteger)2, @"correct number of segments");
+    XCTAssertEqual([redSegments count], (NSUInteger)3, @"correct number of segments");
     XCTAssertEqual([greenSegments count], (NSUInteger)2, @"correct number of segments");
-    XCTAssertEqual([blueSegments count], (NSUInteger)3, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)4, @"correct number of segments");
 
     for (DKUIBezierPathClippedSegment *segment in blueSegments) {
         __block int countOfMoveTo = 0;
@@ -2017,8 +2017,8 @@
     redSegments = [redBlueSegs firstObject];
     blueSegments = [redBlueSegs lastObject];
 
-    XCTAssertEqual([redSegments count], (NSUInteger)4, @"correct number of segments");
-    XCTAssertEqual([blueSegments count], (NSUInteger)3, @"correct number of segments");
+    XCTAssertEqual([redSegments count], (NSUInteger)6, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)4, @"correct number of segments");
 
     for (DKUIBezierPathClippedSegment *segment in blueSegments) {
         __block int countOfMoveTo = 0;
@@ -2047,7 +2047,7 @@
     XCTAssertEqual(blueSegment.startIntersection.elementIndex2, 1, @"correct intersection");
     XCTAssertEqual([self round:blueSegment.startIntersection.tValue2 to:6], (CGFloat)0.733333, @"correct intersection");
     XCTAssertEqual(blueSegment.endIntersection.elementIndex2, 1, @"correct intersection");
-    XCTAssertEqual([self round:blueSegment.endIntersection.tValue2 to:6], (CGFloat)0.733333, @"correct intersection");
+    XCTAssertEqual([self round:blueSegment.endIntersection.tValue2 to:6], (CGFloat)0.733334, @"correct intersection");
 }
 
 - (void)testTangentToSquareHoleInRectangle

--- a/ClippingBezierTests/MMClippingBezierSegmentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTests.m
@@ -2309,4 +2309,19 @@
     XCTAssertEqual([blueSegments count], (NSUInteger)1, @"the curves do intersect");
 }
 
+- (void)testCircleThroughRectangleFindsRedGreenAndBlueSegments2
+{
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+
+    NSArray *redGreenBlueSegs = [UIBezierPath redAndGreenAndBlueSegmentsCreatedFrom:shapePath bySlicingWithPath:scissorPath andNumberOfBlueShellSegments:nil];
+    NSArray *redSegments = [redGreenBlueSegs firstObject];
+    NSArray *greenSegments = [redGreenBlueSegs objectAtIndex:1];
+    NSArray *blueSegments = [redGreenBlueSegs lastObject];
+
+    XCTAssertEqual([redSegments count], (NSUInteger)2, @"correct number of segments");
+    XCTAssertEqual([greenSegments count], (NSUInteger)1, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)3, @"correct number of segments");
+}
+
 @end

--- a/ClippingBezierTests/MMClippingBezierSegmentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTests.m
@@ -474,8 +474,8 @@
                                                                                                     comp:[shapePath isClockwise]];
     XCTAssertTrue(currentSegmentCandidate == correctSegment, @"found correct segment");
 
-    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 5, @"correct intersection");
-    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)1.0, @"correct intersection");
+    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 1, @"correct intersection");
+    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)0.0, @"correct intersection");
     XCTAssertEqual(redSegment.endIntersection.elementIndex1, 1, @"correct intersection");
     XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], (CGFloat)0.45, @"correct intersection");
 
@@ -525,8 +525,8 @@
                                                                                                     comp:[shapePath isClockwise]];
     XCTAssertTrue(currentSegmentCandidate == correctSegment, @"found correct segment");
 
-    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 5, @"correct intersection");
-    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)1.0, @"correct intersection");
+    XCTAssertEqual(redSegment.startIntersection.elementIndex1, 1, @"correct intersection");
+    XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], (CGFloat)0.0, @"correct intersection");
     XCTAssertEqual(redSegment.endIntersection.elementIndex1, 1, @"correct intersection");
     XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], (CGFloat)0.45, @"correct intersection");
 
@@ -923,7 +923,7 @@
     NSArray *blueSegments = [allSegments lastObject];
 
     XCTAssertEqual([redSegments count], (NSUInteger)6, @"correct number of segments");
-    XCTAssertEqual([blueSegments count], (NSUInteger)5, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)6, @"correct number of segments");
 
     DKUIBezierPathClippedSegment *redSegment = [redSegments objectAtIndex:0];
     DKUIBezierPathClippedSegment *correctSegment = [blueSegments objectAtIndex:2];

--- a/ClippingBezierTests/MMClippingBezierSegmentTests.m
+++ b/ClippingBezierTests/MMClippingBezierSegmentTests.m
@@ -1329,7 +1329,7 @@
     XCTAssertEqual(redSegment.startIntersection.elementIndex1, 2, @"correct intersection");
     XCTAssertEqual([self round:redSegment.startIntersection.tValue1 to:6], 0.125865, @"correct intersection");
     XCTAssertEqual(redSegment.endIntersection.elementIndex1, 3, @"correct intersection");
-    XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], 0.183654, @"correct intersection");
+    XCTAssertEqual([self round:redSegment.endIntersection.tValue1 to:6], 0.183655, @"correct intersection");
 
     XCTAssertEqual(currentSegmentCandidate.startIntersection.elementIndex1, 9, @"correct intersection");
     XCTAssertEqual([self round:currentSegmentCandidate.startIntersection.tValue1 to:6], 0.107146, @"correct intersection");
@@ -2112,6 +2112,12 @@
     XCTAssertEqual([self round:blueSegment.endIntersection.tValue2 to:6], (CGFloat).4, @"correct intersection");
 
     blueSegment = [blueSegments objectAtIndex:2];
+    XCTAssertEqual(blueSegment.startIntersection.elementIndex2, 1, @"correct intersection");
+    XCTAssertEqual([self round:blueSegment.startIntersection.tValue2 to:6], (CGFloat)0.6, @"correct intersection");
+    XCTAssertEqual(blueSegment.endIntersection.elementIndex2, 1, @"correct intersection");
+    XCTAssertEqual([self round:blueSegment.endIntersection.tValue2 to:6], (CGFloat)0.866667, @"correct intersection");
+
+    blueSegment = [blueSegments objectAtIndex:3];
     XCTAssertEqual(blueSegment.startIntersection.elementIndex2, 1, @"correct intersection");
     XCTAssertEqual([self round:blueSegment.startIntersection.tValue2 to:6], (CGFloat)0.866667, @"correct intersection");
     XCTAssertEqual(blueSegment.endIntersection.elementIndex2, 1, @"correct intersection");

--- a/ClippingBezierTests/MMClippingBezierSubshapeTests.m
+++ b/ClippingBezierTests/MMClippingBezierSubshapeTests.m
@@ -598,8 +598,8 @@
     XCTAssertEqual([[[foundShapes objectAtIndex:1] segments] count], (NSUInteger)4, @"found closed shape");
     XCTAssertEqual([[[foundShapes objectAtIndex:2] segments] count], (NSUInteger)2, @"found closed shape");
     XCTAssertEqual([[[foundShapes objectAtIndex:3] segments] count], (NSUInteger)2, @"found closed shape");
-    XCTAssertEqual([[[foundShapes objectAtIndex:4] segments] count], (NSUInteger)3, @"found closed shape");
-    XCTAssertEqual([[[foundShapes objectAtIndex:5] segments] count], (NSUInteger)3, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:4] segments] count], (NSUInteger)4, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:5] segments] count], (NSUInteger)4, @"found closed shape");
 
     NSArray *uniqueShapes = [shapePath uniqueShapesCreatedFromSlicingWithUnclosedPath:scissorPath];
     XCTAssertEqual([uniqueShapes count], (NSUInteger)4, @"found shapes");

--- a/ClippingBezierTests/MMClippingBezierSubshapeTests.m
+++ b/ClippingBezierTests/MMClippingBezierSubshapeTests.m
@@ -869,7 +869,7 @@
     NSArray *subShapePaths = [shapePath shapeShellsAndSubshapesCreatedFromSlicingWithUnclosedPath:scissorPath];
     NSArray *foundShapes = [subShapePaths firstObject];
 
-    XCTAssertEqual([foundShapes count], (NSUInteger)2, @"found shapes");
+    XCTAssertEqual([foundShapes count], (NSUInteger)4, @"found shapes");
 
     for (DKUIBezierPathShape *shape in foundShapes) {
         XCTAssertTrue([shape isClosed], @"shape is closed");
@@ -879,7 +879,7 @@
     XCTAssertEqual([[[foundShapes objectAtIndex:1] segments] count], (NSUInteger)2, @"found closed shape");
 
     NSArray *uniqueShapes = [shapePath uniqueShapesCreatedFromSlicingWithUnclosedPath:scissorPath];
-    XCTAssertEqual([uniqueShapes count], (NSUInteger)2, @"found shapes");
+    XCTAssertEqual([uniqueShapes count], (NSUInteger)3, @"found shapes");
     for (DKUIBezierPathShape *shape in uniqueShapes) {
         XCTAssertTrue([shape isClosed], @"shape is closed");
         XCTAssertEqual([shape.holes count], (NSUInteger)0, @"shape is closed");
@@ -1709,16 +1709,16 @@
     NSArray *greenSegments = [redGreenBlueSegs objectAtIndex:1];
     NSArray *blueSegments = [redGreenBlueSegs lastObject];
 
-    XCTAssertEqual([redSegments count], (NSUInteger)2, @"correct number of segments");
+    XCTAssertEqual([redSegments count], (NSUInteger)3, @"correct number of segments");
     XCTAssertEqual([greenSegments count], (NSUInteger)2, @"correct number of segments");
-    XCTAssertEqual([blueSegments count], (NSUInteger)3, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)4, @"correct number of segments");
 
     NSArray *redBlueSegs = [UIBezierPath redAndBlueSegmentsForShapeBuildingCreatedFrom:shapePath bySlicingWithPath:scissorPath andNumberOfBlueShellSegments:nil];
     redSegments = [redBlueSegs firstObject];
     blueSegments = [redBlueSegs lastObject];
 
-    XCTAssertEqual([redSegments count], (NSUInteger)4, @"correct number of segments");
-    XCTAssertEqual([blueSegments count], (NSUInteger)3, @"correct number of segments");
+    XCTAssertEqual([redSegments count], (NSUInteger)6, @"correct number of segments");
+    XCTAssertEqual([blueSegments count], (NSUInteger)4, @"correct number of segments");
 
     NSArray *subShapePaths = [shapePath shapeShellsAndSubshapesCreatedFromSlicingWithUnclosedPath:scissorPath];
     NSArray *foundShapes = [subShapePaths firstObject];
@@ -1731,8 +1731,8 @@
 
     XCTAssertEqual([[[foundShapes objectAtIndex:0] segments] count], (NSUInteger)4, @"found closed shape");
     XCTAssertEqual([[[foundShapes objectAtIndex:1] segments] count], (NSUInteger)4, @"found closed shape");
-    XCTAssertEqual([[[foundShapes objectAtIndex:2] segments] count], (NSUInteger)3, @"found closed shape");
-    XCTAssertEqual([[[foundShapes objectAtIndex:3] segments] count], (NSUInteger)3, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:2] segments] count], (NSUInteger)4, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:3] segments] count], (NSUInteger)4, @"found closed shape");
 
     NSArray *uniqueShapes = [shapePath uniqueShapesCreatedFromSlicingWithUnclosedPath:scissorPath];
     XCTAssertEqual([uniqueShapes count], (NSUInteger)2, @"found shapes");

--- a/ClippingBezierTests/MMClippingBezierSubshapeTests.m
+++ b/ClippingBezierTests/MMClippingBezierSubshapeTests.m
@@ -2423,4 +2423,50 @@
     XCTAssertTrue([difference isEqualToBezierPath:calcDifference withAccuracy:0.000001], @"shape is very small from the knot");
 }
 
+
+- (void)testCircleThroughReversedRectangleFirstSegmentTangent2
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+
+    NSArray *foundShapes = [shapePath uniqueShapesCreatedFromSlicingWithUnclosedPath:scissorPath];
+
+    XCTAssertEqual([foundShapes count], (NSUInteger)3);
+
+    for (DKUIBezierPathShape *shape in foundShapes) {
+        XCTAssertTrue([shape isClosed]);
+    }
+}
+
+- (void)testCircleThroughRectangleFirstSegmentTangent3
+{
+    // here, the scissor is a circle that is contained with in a square shape
+    // the square wraps around the outside of the circle
+    UIBezierPath *scissorPath = [UIBezierPath bezierPathWithOvalInRect:CGRectMake(200, 200, 200, 200)];
+    UIBezierPath *shapePath = [UIBezierPath bezierPathWithRect:CGRectMake(200, 200, 200, 100)];
+
+    NSArray *subShapePaths = [shapePath shapeShellsAndSubshapesCreatedFromSlicingWithUnclosedPath:scissorPath];
+    NSArray *foundShapes = [subShapePaths firstObject];
+
+    XCTAssertEqual([foundShapes count], (NSUInteger)4, @"found shapes");
+
+    for (DKUIBezierPathShape *shape in foundShapes) {
+        XCTAssertTrue([shape isClosed], @"shape is closed");
+    }
+
+    XCTAssertEqual([[[foundShapes objectAtIndex:0] segments] count], (NSUInteger)3, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:1] segments] count], (NSUInteger)3, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:2] segments] count], (NSUInteger)2, @"found closed shape");
+    XCTAssertEqual([[[foundShapes objectAtIndex:3] segments] count], (NSUInteger)2, @"found closed shape");
+
+    NSArray *uniqueShapes = [shapePath uniqueShapesCreatedFromSlicingWithUnclosedPath:scissorPath];
+    XCTAssertEqual([uniqueShapes count], (NSUInteger)3, @"found shapes");
+    for (DKUIBezierPathShape *shape in uniqueShapes) {
+        XCTAssertTrue([shape isClosed], @"shape is closed");
+        XCTAssertEqual([shape.holes count], (NSUInteger)0, @"shape is closed");
+    }
+}
+
 @end

--- a/ClippingBezierTests/MMClippingBezierUnionTest.m
+++ b/ClippingBezierTests/MMClippingBezierUnionTest.m
@@ -150,6 +150,23 @@
     XCTAssert([unionPath isEqualToBezierPath:[finalShapes firstObject] withAccuracy:0.00001]);
 }
 
+- (void)testUnionToHole2
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPathWithRect:CGRectMake(0, 0, 100, 100)];
+    UIBezierPath *path2 = [UIBezierPath bezierPathWithRect:CGRectMake(25, 25, 50, 50)];
+
+    NSArray<UIBezierPath *> *combined1 = [path1 unionWithPath:path2];
+    NSArray<UIBezierPath *> *combined2 = [path1 unionWithPath:[path2 bezierPathByReversingPath]];
+    NSArray<UIBezierPath *> *combined3 = [path2 unionWithPath:path1];
+
+    XCTAssertEqual([combined1 count], 1);
+    XCTAssertEqual([combined2 count], 1);
+    XCTAssertEqual([combined3 count], 1);
+    XCTAssert([path1 isEqualToBezierPath:[combined1 firstObject] withAccuracy:0.00001]);
+    XCTAssert([path1 isEqualToBezierPath:[combined2 firstObject] withAccuracy:0.00001]);
+    XCTAssert([path1 isEqualToBezierPath:[combined3 firstObject] withAccuracy:0.00001]);
+}
+
 - (void)testUnionToHole
 {
     UIBezierPath *path1 = [UIBezierPath bezierPath];
@@ -177,20 +194,23 @@
     XCTAssertEqual([finalShapes count], 1);
 
     UIBezierPath *unionPath = [UIBezierPath bezierPath];
-    [unionPath moveToPoint:CGPointMake(70.000000, 80.000000)];
-    [unionPath addLineToPoint:CGPointMake(70.000000, 20.000000)];
-    [unionPath addLineToPoint:CGPointMake(50.000000, 20.000000)];
-    [unionPath addLineToPoint:CGPointMake(50.000000, 80.000000)];
-    [unionPath addLineToPoint:CGPointMake(70.000000, 80.000000)];
-    [unionPath addLineToPoint:CGPointMake(100.000000, 80.000000)];
-    [unionPath addLineToPoint:CGPointMake(100.000000, 100.000000)];
-    [unionPath addLineToPoint:CGPointMake(0.000000, 100.000000)];
-    [unionPath addLineToPoint:CGPointMake(0.000000, 0.000000)];
-    [unionPath addLineToPoint:CGPointMake(100.000000, 0.000000)];
-    [unionPath addLineToPoint:CGPointMake(100.000000, 20.000000)];
-    [unionPath addLineToPoint:CGPointMake(100.000000, 20.000000)];
-    [unionPath addLineToPoint:CGPointMake(80.000000, 20.000000)];
-    [unionPath addLineToPoint:CGPointMake(80.000000, 80.000000)];
+    [unionPath moveToPoint:CGPointMake(80.00000000000001, 80)];
+    [unionPath addLineToPoint:CGPointMake(100, 80)];
+    [unionPath addLineToPoint:CGPointMake(100, 100)];
+    [unionPath addLineToPoint:CGPointMake(0, 100)];
+    [unionPath addLineToPoint:CGPointMake(0, 0)];
+    [unionPath addLineToPoint:CGPointMake(100, 0)];
+    [unionPath addLineToPoint:CGPointMake(100, 20)];
+    [unionPath addLineToPoint:CGPointMake(100, 20)];
+    [unionPath addLineToPoint:CGPointMake(80, 20)];
+    [unionPath addLineToPoint:CGPointMake(80, 80)];
+    [unionPath closePath];
+    [unionPath moveToPoint:CGPointMake(70, 80)];
+    [unionPath addLineToPoint:CGPointMake(70, 20)];
+    [unionPath addLineToPoint:CGPointMake(50, 20)];
+    [unionPath addLineToPoint:CGPointMake(50, 80)];
+    [unionPath addLineToPoint:CGPointMake(70, 80)];
+    [unionPath closePath];
 
     XCTAssert([unionPath isEqualToBezierPath:[finalShapes firstObject] withAccuracy:0.00001]);
 }

--- a/ClippingBezierTests/MMClippingBezierUnionTest.m
+++ b/ClippingBezierTests/MMClippingBezierUnionTest.m
@@ -269,4 +269,113 @@
     XCTAssertEqual([finalShapes count], 1);
 }
 
+- (void)testUnionInvalidGlue2
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(620.8655482851358, 335.9684147785148)];
+    [path1 addLineToPoint:CGPointMake(622.9875061968842, 296.6951167729743)];
+    [path1 addLineToPoint:CGPointMake(624.3363026235381, 271.7315283250078)];
+    [path1 addLineToPoint:CGPointMake(574.4091257276052, 269.0339354716999)];
+    [path1 addLineToPoint:CGPointMake(573.0603293009513, 293.9975239196664)];
+    [path1 addLineToPoint:CGPointMake(572.1602689738288, 310.6558832840694)];
+    [path1 addLineToPoint:CGPointMake(570.6088626418198, 310.6714746350677)];
+    [path1 addLineToPoint:CGPointMake(570.6202306904594, 311.8029480841565)];
+    [path1 addLineToPoint:CGPointMake(541.6974183423137, 311.3675532899119)];
+    [path1 addLineToPoint:CGPointMake(541.3338926009072, 335.5163883955379)];
+    [path1 addLineToPoint:CGPointMake(542.8796385873932, 335.4733551188858)];
+    [path1 addLineToPoint:CGPointMake(541.3338620077711, 335.5163772713557)];
+    [path1 addLineToPoint:CGPointMake(540.5490725877183, 335.5382195806076)];
+    [path1 addLineToPoint:CGPointMake(540.2847076854124, 335.5455774014496)];
+    [path1 addLineToPoint:CGPointMake(540.400733400935, 339.7143561210604)];
+    [path1 addLineToPoint:CGPointMake(540.9653264397846, 360.0000611907789)];
+    [path1 addLineToPoint:CGPointMake(540.9488110781331, 361.0971682635864)];
+    [path1 addLineToPoint:CGPointMake(539.7621196643465, 361.1906105536563)];
+    [path1 addLineToPoint:CGPointMake(540.7571511930203, 373.8290702513436)];
+    [path1 addLineToPoint:CGPointMake(540.5970987444573, 384.4612396663441)];
+    [path1 addLineToPoint:CGPointMake(541.5953977943913, 384.4762676128553)];
+    [path1 addLineToPoint:CGPointMake(541.5954088784055, 384.4762564637616)];
+    [path1 addLineToPoint:CGPointMake(541.6745141138086, 385.4810169167816)];
+    [path1 addLineToPoint:CGPointMake(542.3523955832679, 409.8371537864492)];
+    [path1 addLineToPoint:CGPointMake(543.5893552536579, 409.8027266459165)];
+    [path1 addLineToPoint:CGPointMake(543.7675196162107, 412.0656736292227)];
+    [path1 addLineToPoint:CGPointMake(543.7675163025195, 412.065667385881)];
+    [path1 addLineToPoint:CGPointMake(542.7217948625087, 412.193467788793)];
+    [path1 addLineToPoint:CGPointMake(545.6892690622128, 436.4747010447309)];
+    [path1 addLineToPoint:CGPointMake(547.256607668511, 456.3823534867533)];
+    [path1 addLineToPoint:CGPointMake(547.2090844239942, 456.3899454455105)];
+    [path1 addLineToPoint:CGPointMake(547.3038580843761, 456.9825094175761)];
+    [path1 addLineToPoint:CGPointMake(547.6092252722709, 460.861148733922)];
+    [path1 addLineToPoint:CGPointMake(547.9202872018868, 460.836658690456)];
+    [path1 addLineToPoint:CGPointMake(547.9202859278228, 460.8366702670407)];
+    [path1 addLineToPoint:CGPointMake(551.0843385438143, 480.6196308322495)];
+    [path1 addLineToPoint:CGPointMake(552.0013655807721, 488.1231661580025)];
+    [path1 addLineToPoint:CGPointMake(550.9149313889463, 488.3613883024607)];
+    [path1 addLineToPoint:CGPointMake(553.4350065814868, 499.8538798573999)];
+    [path1 addLineToPoint:CGPointMake(553.5562383675456, 500.8458526592783)];
+    [path1 addLineToPoint:CGPointMake(553.5562167332262, 500.8458661326099)];
+    [path1 addLineToPoint:CGPointMake(551.4737863047027, 501.5162431495522)];
+    [path1 addLineToPoint:CGPointMake(557.3419757943045, 519.7449354296439)];
+    [path1 addLineToPoint:CGPointMake(557.6876419908559, 521.9061857788848)];
+    [path1 addLineToPoint:CGPointMake(557.6876304032364, 521.9061989967712)];
+    [path1 addLineToPoint:CGPointMake(551.7361215956352, 526.8497639642151)];
+    [path1 addLineToPoint:CGPointMake(559.608991631909, 536.3278340756736)];
+    [path1 addLineToPoint:CGPointMake(556.6849026489824, 541.2354474548087)];
+    [path1 addLineToPoint:CGPointMake(563.3845007933223, 545.2272686133632)];
+    [path1 addLineToPoint:CGPointMake(563.3980516029808, 545.2890668199545)];
+    [path1 addLineToPoint:CGPointMake(562.8125648293126, 547.7397520982714)];
+    [path1 addLineToPoint:CGPointMake(564.4086952067518, 548.1210778424395)];
+    [path1 addLineToPoint:CGPointMake(564.6698715820489, 558.2419728406546)];
+    [path1 addLineToPoint:CGPointMake(569.6932379205355, 558.1123285477497)];
+    [path1 addLineToPoint:CGPointMake(570.8046630629718, 561.5648500589339)];
+    [path1 addLineToPoint:CGPointMake(578.5111645923483, 559.083969336312)];
+    [path1 addLineToPoint:CGPointMake(585.7596124490634, 567.8103069757932)];
+    [path1 addLineToPoint:CGPointMake(592.245064125681, 562.4232273724448)];
+    [path1 addLineToPoint:CGPointMake(592.2450412897059, 562.4232427178869)];
+    [path1 addLineToPoint:CGPointMake(599.6383695327306, 566.8284090393294)];
+    [path1 addLineToPoint:CGPointMake(605.005848754226, 557.8200009960352)];
+    [path1 addLineToPoint:CGPointMake(605.00586109355, 557.8200001308174)];
+    [path1 addLineToPoint:CGPointMake(611.4439728774923, 559.3581061663584)];
+    [path1 addLineToPoint:CGPointMake(612.0024677196927, 557.0203920284805)];
+    [path1 addLineToPoint:CGPointMake(616.5947866934684, 556.9018816647043)];
+    [path1 addLineToPoint:CGPointMake(616.3889028562965, 548.9244388161709)];
+    [path1 addLineToPoint:CGPointMake(617.6134317218899, 549.0197381941508)];
+    [path1 addLineToPoint:CGPointMake(617.8148593397586, 546.431272777373)];
+    [path1 addLineToPoint:CGPointMake(618.3992656433492, 546.2431724348635)];
+    [path1 addLineToPoint:CGPointMake(617.9404139268344, 544.8178151321787)];
+    [path1 addLineToPoint:CGPointMake(617.9404148839437, 544.8178089065933)];
+    [path1 addLineToPoint:CGPointMake(618.2514088395587, 540.8213504891512)];
+    [path1 addLineToPoint:CGPointMake(624.2215623870485, 535.862249022798)];
+    [path1 addLineToPoint:CGPointMake(620.6505188961908, 531.5631052008537)];
+    [path1 addLineToPoint:CGPointMake(627.2106601215804, 520.5529724586113)];
+    [path1 addLineToPoint:CGPointMake(621.5242165383243, 517.1648191211241)];
+    [path1 addLineToPoint:CGPointMake(624.7532360364884, 503.6489924904732)];
+    [path1 addLineToPoint:CGPointMake(621.5496811169817, 502.8836427540537)];
+    [path1 addLineToPoint:CGPointMake(621.5496552988566, 502.8836361371166)];
+    [path1 addLineToPoint:CGPointMake(621.6149533764311, 497.5977786189702)];
+    [path1 addLineToPoint:CGPointMake(623.4911667655792, 473.4873258538677)];
+    [path1 addLineToPoint:CGPointMake(622.2462154236187, 473.3904469921498)];
+    [path1 addLineToPoint:CGPointMake(622.2462430542701, 473.390441620871)];
+    [path1 addLineToPoint:CGPointMake(622.0972223383477, 458.5582581236094)];
+    [path1 addLineToPoint:CGPointMake(622.402573974387, 433.8401549064158)];
+    [path1 addLineToPoint:CGPointMake(621.8488159037889, 433.8333141360531)];
+    [path1 addLineToPoint:CGPointMake(620.8655476263901, 335.968414225503)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(622.8006134346539, 298.6802895867939)];
+    [path2 addLineToPoint:CGPointMake(626.3079727420134, 272.6150298465341)];
+    [path2 addLineToPoint:CGPointMake(629.641941982487, 247.838334160798)];
+    [path2 addLineToPoint:CGPointMake(580.0885506110146, 241.1703956798509)];
+    [path2 addLineToPoint:CGPointMake(576.754581370541, 265.947091365587)];
+    [path2 addLineToPoint:CGPointMake(573.2472220631815, 292.0123511058468)];
+    [path2 addLineToPoint:CGPointMake(569.9132528227079, 316.7890467915829)];
+    [path2 addLineToPoint:CGPointMake(619.4666441941803, 323.45698527253)];
+    [path2 addLineToPoint:CGPointMake(622.8006134346539, 298.6802895867939)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+}
+
 @end

--- a/ClippingBezierTests/MMClippingBezierUnionTest.m
+++ b/ClippingBezierTests/MMClippingBezierUnionTest.m
@@ -238,18 +238,18 @@
     [path1 moveToPoint:CGPointMake(543.55434286947127, 292.31630286084135)];
     [path1 addLineToPoint:CGPointMake(542.05434286947127, 297.31630286084135)];
     [path1 addCurveToPoint:CGPointMake(558.81630286084135, 328.44565713052879)
-            controlPoint1:CGPointMake(538.0868964921109, 310.54112411870938)
-            controlPoint2:CGPointMake(545.59148160297332, 324.47821075316836)];
+             controlPoint1:CGPointMake(538.0868964921109, 310.54112411870938)
+             controlPoint2:CGPointMake(545.59148160297332, 324.47821075316836)];
     [path1 addCurveToPoint:CGPointMake(589.94565713052873, 311.68369713915865)
-            controlPoint1:CGPointMake(572.04112411870938, 332.41310350788922)
-            controlPoint2:CGPointMake(585.97821075316836, 324.90851839702668)];
+             controlPoint1:CGPointMake(572.04112411870938, 332.41310350788922)
+             controlPoint2:CGPointMake(585.97821075316836, 324.90851839702668)];
     [path1 addLineToPoint:CGPointMake(591.44565713052873, 306.68369713915865)];
     [path1 addCurveToPoint:CGPointMake(574.68369713915865, 275.55434286947121)
-            controlPoint1:CGPointMake(595.4131035078891, 293.45887588129062)
-            controlPoint2:CGPointMake(587.90851839702668, 279.52178924683164)];
+             controlPoint1:CGPointMake(595.4131035078891, 293.45887588129062)
+             controlPoint2:CGPointMake(587.90851839702668, 279.52178924683164)];
     [path1 addCurveToPoint:CGPointMake(543.55434286947127, 292.31630286084135)
-            controlPoint1:CGPointMake(561.45887588129062, 271.58689649211078)
-            controlPoint2:CGPointMake(547.52178924683164, 279.09148160297332)];
+             controlPoint1:CGPointMake(561.45887588129062, 271.58689649211078)
+             controlPoint2:CGPointMake(547.52178924683164, 279.09148160297332)];
     [path1 closePath];
 
     UIBezierPath *path2 = [UIBezierPath bezierPath];

--- a/ClippingBezierTests/MMClippingBezierUnionTest.m
+++ b/ClippingBezierTests/MMClippingBezierUnionTest.m
@@ -195,4 +195,78 @@
     XCTAssert([unionPath isEqualToBezierPath:[finalShapes firstObject] withAccuracy:0.00001]);
 }
 
+- (void)testUnionSimilarValidGlue
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(543.554343, 292.316303)];
+    [path1 addLineToPoint:CGPointMake(542.054343, 297.316303)];
+    [path1 addCurveToPoint:CGPointMake(558.816303, 328.445657)
+             controlPoint1:CGPointMake(538.086896, 310.541124)
+             controlPoint2:CGPointMake(545.591482, 324.478211)];
+    [path1 addCurveToPoint:CGPointMake(589.945657, 311.683697)
+             controlPoint1:CGPointMake(572.041124, 332.413104)
+             controlPoint2:CGPointMake(585.978211, 324.908518)];
+    [path1 addLineToPoint:CGPointMake(591.445657, 306.683697)];
+    [path1 addCurveToPoint:CGPointMake(574.683697, 275.554343)
+             controlPoint1:CGPointMake(595.413104, 293.458876)
+             controlPoint2:CGPointMake(587.908518, 279.521789)];
+    [path1 addCurveToPoint:CGPointMake(543.554343, 292.316303)
+             controlPoint1:CGPointMake(561.458876, 271.586896)
+             controlPoint2:CGPointMake(547.521789, 279.091482)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(541.114837, 302.106538)];
+    [path2 addLineToPoint:CGPointMake(540.614837, 307.305110)];
+    [path2 addLineToPoint:CGPointMake(538.221375, 332.190273)];
+    [path2 addLineToPoint:CGPointMake(587.991701, 336.977196)];
+    [path2 addLineToPoint:CGPointMake(590.385163, 312.092033)];
+    [path2 addLineToPoint:CGPointMake(590.885163, 306.893462)];
+    [path2 addLineToPoint:CGPointMake(593.278625, 282.008299)];
+    [path2 addLineToPoint:CGPointMake(543.508299, 277.221375)];
+    [path2 addLineToPoint:CGPointMake(541.114837, 302.106538)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+}
+
+- (void)testUnionInvalidGlue
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(543.55434286947127, 292.31630286084135)];
+    [path1 addLineToPoint:CGPointMake(542.05434286947127, 297.31630286084135)];
+    [path1 addCurveToPoint:CGPointMake(558.81630286084135, 328.44565713052879)
+            controlPoint1:CGPointMake(538.0868964921109, 310.54112411870938)
+            controlPoint2:CGPointMake(545.59148160297332, 324.47821075316836)];
+    [path1 addCurveToPoint:CGPointMake(589.94565713052873, 311.68369713915865)
+            controlPoint1:CGPointMake(572.04112411870938, 332.41310350788922)
+            controlPoint2:CGPointMake(585.97821075316836, 324.90851839702668)];
+    [path1 addLineToPoint:CGPointMake(591.44565713052873, 306.68369713915865)];
+    [path1 addCurveToPoint:CGPointMake(574.68369713915865, 275.55434286947121)
+            controlPoint1:CGPointMake(595.4131035078891, 293.45887588129062)
+            controlPoint2:CGPointMake(587.90851839702668, 279.52178924683164)];
+    [path1 addCurveToPoint:CGPointMake(543.55434286947127, 292.31630286084135)
+            controlPoint1:CGPointMake(561.45887588129062, 271.58689649211078)
+            controlPoint2:CGPointMake(547.52178924683164, 279.09148160297332)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(541.1148369272471, 302.10653831396985)];
+    [path2 addLineToPoint:CGPointMake(540.6148369272471, 307.30510974254122)];
+    [path2 addLineToPoint:CGPointMake(538.22137524121695, 332.19027281529412)];
+    [path2 addLineToPoint:CGPointMake(587.99170138672275, 336.97719618735442)];
+    [path2 addLineToPoint:CGPointMake(590.3851630727529, 312.09203311460152)];
+    [path2 addLineToPoint:CGPointMake(590.8851630727529, 306.89346168603015)];
+    [path2 addLineToPoint:CGPointMake(593.27862475878305, 282.00829861327725)];
+    [path2 addLineToPoint:CGPointMake(543.50829861327725, 277.22137524121695)];
+    [path2 addLineToPoint:CGPointMake(541.1148369272471, 302.10653831396985)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+}
+
 @end

--- a/ClippingBezierTests/MMClippingBezierUnionTest.m
+++ b/ClippingBezierTests/MMClippingBezierUnionTest.m
@@ -215,7 +215,77 @@
     XCTAssert([unionPath isEqualToBezierPath:[finalShapes firstObject] withAccuracy:0.00001]);
 }
 
-- (void)testUnionSimilarValidGlue
+- (void)testUnionPaths1
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(301.378178, 494.217308)];
+    [path1 addCurveToPoint:CGPointMake(291.404879, 501.361164) controlPoint1:CGPointMake(297.498984, 495.740229) controlPoint2:CGPointMake(294.072618, 498.20994)];
+    [path1 addCurveToPoint:CGPointMake(285.562701, 515.730504) controlPoint1:CGPointMake(288.0951, 505.270788) controlPoint2:CGPointMake(285.953045, 510.229435)];
+    [path1 addLineToPoint:CGPointMake(285.562701, 515.730504)];
+    [path1 addLineToPoint:CGPointMake(285.492788, 516.715785)];
+    [path1 addCurveToPoint:CGPointMake(289.992167, 532.884229) controlPoint1:CGPointMake(285.068291, 522.698162) controlPoint2:CGPointMake(286.785267, 528.338002)];
+    [path1 addCurveToPoint:CGPointMake(308.66059, 543.42258) controlPoint1:CGPointMake(294.168117, 538.804221) controlPoint2:CGPointMake(300.870477, 542.869811)];
+    [path1 addCurveToPoint:CGPointMake(324.829034, 538.9232019999999) controlPoint1:CGPointMake(314.642967, 543.847077) controlPoint2:CGPointMake(320.282807, 542.130101)];
+    [path1 addCurveToPoint:CGPointMake(335.367386, 520.254778) controlPoint1:CGPointMake(330.749026, 534.747252) controlPoint2:CGPointMake(334.814616, 528.044891)];
+    [path1 addLineToPoint:CGPointMake(335.437299, 519.269496)];
+    [path1 addCurveToPoint:CGPointMake(312.269496, 492.562701) controlPoint1:CGPointMake(336.414565, 505.497006) controlPoint2:CGPointMake(326.041986, 493.539967)];
+    [path1 addCurveToPoint:CGPointMake(301.378178, 494.217308) controlPoint1:CGPointMake(308.432032, 492.290403) controlPoint2:CGPointMake(304.735512, 492.899263)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(332.461371, 533.261389)];
+    [path2 addLineToPoint:CGPointMake(347.246111, 525.011606)];
+    [path2 addLineToPoint:CGPointMake(369.077413, 512.829889)];
+    [path2 addLineToPoint:CGPointMake(344.71398, 469.167284)];
+    [path2 addLineToPoint:CGPointMake(322.882677, 481.349)];
+    [path2 addLineToPoint:CGPointMake(308.097937, 489.598784)];
+    [path2 addLineToPoint:CGPointMake(286.266634, 501.780501)];
+    [path2 addLineToPoint:CGPointMake(310.630068, 545.4431059999999)];
+    [path2 addLineToPoint:CGPointMake(332.461371, 533.261389)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
+}
+
+- (void)testUnionPaths2
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(301.3781783143294, 494.2173077800095)];
+    [path1 addCurveToPoint:CGPointMake(291.4048786452396, 501.3611643534879) controlPoint1:CGPointMake(297.4989840540441, 495.7402286767368) controlPoint2:CGPointMake(294.0726175254794, 498.2099400369437)];
+    [path1 addCurveToPoint:CGPointMake(285.562700977999, 515.7305036063025) controlPoint1:CGPointMake(288.0951001606109, 505.2707877879222) controlPoint2:CGPointMake(285.9530448172198, 510.2294350114649)];
+    [path1 addLineToPoint:CGPointMake(285.562700977999, 515.7305036063025)];
+    [path1 addLineToPoint:CGPointMake(285.4927875580855, 516.7157849915839)];
+    [path1 addCurveToPoint:CGPointMake(289.9921668684398, 532.8842294722783) controlPoint1:CGPointMake(285.0682911191082, 522.6981620511009) controlPoint2:CGPointMake(286.7852673935041, 528.3380024849246)];
+    [path1 addCurveToPoint:CGPointMake(308.660590186389, 543.4225804072823) controlPoint1:CGPointMake(294.1681171128794, 538.8042209929039) controlPoint2:CGPointMake(300.8704772940846, 542.8698109731399)];
+    [path1 addCurveToPoint:CGPointMake(324.8290337056694, 538.9232017751076) controlPoint1:CGPointMake(314.6429668241981, 543.8470768163363) controlPoint2:CGPointMake(320.2828068846058, 542.1301008139289)];
+    [path1 addCurveToPoint:CGPointMake(335.3673856020876, 520.2547777789789) controlPoint1:CGPointMake(330.7490257475378, 534.7472515781362) controlPoint2:CGPointMake(334.8146161380217, 528.0448910929913)];
+    [path1 addLineToPoint:CGPointMake(335.437299022001, 519.2694963936975)];
+    [path1 addCurveToPoint:CGPointMake(312.2694963936975, 492.562700977999) controlPoint1:CGPointMake(336.4145648951207, 505.497006441876) controlPoint2:CGPointMake(326.041986345519, 493.5399668511187)];
+    [path1 addCurveToPoint:CGPointMake(301.3781783143294, 494.2173077800095) controlPoint1:CGPointMake(308.4320317626604, 492.2904028506207) controlPoint2:CGPointMake(304.735511660335, 492.8992626482518)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(332.461370621175, 533.2613891604791)];
+    [path2 addLineToPoint:CGPointMake(347.2461108809152, 525.0116056106955)];
+    [path2 addLineToPoint:CGPointMake(369.0774134613077, 512.8298886691741)];
+    [path2 addLineToPoint:CGPointMake(344.7139795782651, 469.1672835083892)];
+    [path2 addLineToPoint:CGPointMake(322.8826769978726, 481.3490004499105)];
+    [path2 addLineToPoint:CGPointMake(308.0979367381324, 489.598783999694)];
+    [path2 addLineToPoint:CGPointMake(286.2666341577399, 501.7805009412153)];
+    [path2 addLineToPoint:CGPointMake(310.6300680407825, 545.4431061020005)];
+    [path2 addLineToPoint:CGPointMake(332.461370621175, 533.2613891604791)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
+}
+
+- (void)testUnionPaths3Rounded
 {
     UIBezierPath *path1 = [UIBezierPath bezierPath];
     [path1 moveToPoint:CGPointMake(543.554343, 292.316303)];
@@ -250,9 +320,10 @@
     NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
 
     XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
 }
 
-- (void)testUnionInvalidGlue
+- (void)testUnionPaths3
 {
     UIBezierPath *path1 = [UIBezierPath bezierPath];
     [path1 moveToPoint:CGPointMake(543.55434286947127, 292.31630286084135)];
@@ -287,9 +358,270 @@
     NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
 
     XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
 }
 
-- (void)testUnionInvalidGlue2
+- (void)testUnionPaths4
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(586.5546859618685, 501.0049007443614)];
+    [path1 addLineToPoint:CGPointMake(603.6917332760196, 498.9105365402114)];
+    [path1 addLineToPoint:CGPointMake(600.6589812284618, 474.0951700303644)];
+    [path1 addLineToPoint:CGPointMake(597.2776662249053, 446.4277017432444)];
+    [path1 addLineToPoint:CGPointMake(598.6817287764064, 446.3777826175018)];
+    [path1 addLineToPoint:CGPointMake(598.2557548774608, 434.4046929783055)];
+    [path1 addLineToPoint:CGPointMake(598.255757752456, 434.4046973894274)];
+    [path1 addLineToPoint:CGPointMake(600.0765864530991, 424.5704110987463)];
+    [path1 addLineToPoint:CGPointMake(597.8914788349319, 424.1658360693491)];
+    [path1 addLineToPoint:CGPointMake(597.845785036679, 422.8814384662383)];
+    [path1 addLineToPoint:CGPointMake(598.4195530453338, 416.0176084236699)];
+    [path1 addLineToPoint:CGPointMake(598.9005854980256, 415.9746631257495)];
+    [path1 addLineToPoint:CGPointMake(598.6540658843851, 413.2122180647474)];
+    [path1 addLineToPoint:CGPointMake(598.6540643192939, 413.2122202066951)];
+    [path1 addLineToPoint:CGPointMake(599.8043308699894, 399.4519255598385)];
+    [path1 addLineToPoint:CGPointMake(597.4082024416637, 399.2516256060214)];
+    [path1 addLineToPoint:CGPointMake(596.7378154843714, 391.7391337328909)];
+    [path1 addLineToPoint:CGPointMake(596.7378163445783, 391.7391349101218)];
+    [path1 addLineToPoint:CGPointMake(595.8726960374154, 367.4227084530307)];
+    [path1 addLineToPoint:CGPointMake(594.5719601426955, 367.4689855258055)];
+    [path1 addLineToPoint:CGPointMake(591.7315838278868, 335.6403793918167)];
+    [path1 addLineToPoint:CGPointMake(594.340144997684, 319.6927788984932)];
+    [path1 addLineToPoint:CGPointMake(594.3401508858758, 319.6927659222111)];
+    [path1 addLineToPoint:CGPointMake(594.8105322706595, 319.7604657759737)];
+    [path1 addLineToPoint:CGPointMake(596.198510838496, 310.1167332639626)];
+    [path1 addLineToPoint:CGPointMake(596.1984856617421, 310.1167349879589)];
+    [path1 addLineToPoint:CGPointMake(596.6099435393584, 310.1689451693507)];
+    [path1 addLineToPoint:CGPointMake(599.0729543075099, 290.758455563808)];
+    [path1 addLineToPoint:CGPointMake(599.5399161687859, 287.9036558711749)];
+    [path1 addLineToPoint:CGPointMake(599.5399170553948, 287.9036565639494)];
+    [path1 addLineToPoint:CGPointMake(604.7594798171671, 287.3125082593189)];
+    [path1 addLineToPoint:CGPointMake(602.4348079328421, 266.7867439025244)];
+    [path1 addLineToPoint:CGPointMake(603.2623056028136, 261.037195002068)];
+    [path1 addLineToPoint:CGPointMake(603.2369377416157, 261.0335439211602)];
+    [path1 addLineToPoint:CGPointMake(608.0044915928995, 245.58415456029)];
+    [path1 addLineToPoint:CGPointMake(604.9257197436657, 244.6340652475577)];
+    [path1 addLineToPoint:CGPointMake(605.0530360784416, 243.6306408762261)];
+    [path1 addLineToPoint:CGPointMake(599.7358391613545, 242.9559379949846)];
+    [path1 addLineToPoint:CGPointMake(598.7720320688427, 234.4461478884606)];
+    [path1 addLineToPoint:CGPointMake(579.123046312684, 236.6715190828699)];
+    [path1 addLineToPoint:CGPointMake(579.1230465124466, 236.6715252227085)];
+    [path1 addLineToPoint:CGPointMake(560.2276610537965, 230.8405300521222)];
+    [path1 addLineToPoint:CGPointMake(558.1185556991254, 237.6751024507487)];
+    [path1 addLineToPoint:CGPointMake(555.4507707463559, 237.3365743111688)];
+    [path1 addLineToPoint:CGPointMake(555.1912323490045, 239.3819439170066)];
+    [path1 addLineToPoint:CGPointMake(549.0896543819672, 240.0729895761789)];
+    [path1 addLineToPoint:CGPointMake(551.0116322985548, 257.0431547340426)];
+    [path1 addLineToPoint:CGPointMake(551.011636516994, 257.0431482456252)];
+    [path1 addLineToPoint:CGPointMake(549.6201483204835, 265.2142588238856)];
+    [path1 addLineToPoint:CGPointMake(548.0606438198089, 270.2678450297012)];
+    [path1 addLineToPoint:CGPointMake(548.0606695021762, 270.2678459523191)];
+    [path1 addLineToPoint:CGPointMake(546.6636356420688, 270.15395759191)];
+    [path1 addLineToPoint:CGPointMake(546.149475906873, 276.460998601125)];
+    [path1 addLineToPoint:CGPointMake(545.8454593673839, 277.4461671103816)];
+    [path1 addLineToPoint:CGPointMake(543.5082986132772, 277.2213752412169)];
+    [path1 addLineToPoint:CGPointMake(542.7849887483235, 284.7417312371214)];
+    [path1 addLineToPoint:CGPointMake(542.7849731422747, 284.7417285498717)];
+    [path1 addLineToPoint:CGPointMake(540.4524971109955, 284.746164750551)];
+    [path1 addLineToPoint:CGPointMake(540.4822257978358, 300.3769836672548)];
+    [path1 addLineToPoint:CGPointMake(540.482238083743, 300.376975957792)];
+    [path1 addLineToPoint:CGPointMake(538.4025530301129, 300.5625663114799)];
+    [path1 addLineToPoint:CGPointMake(539.7794026362358, 315.991242910503)];
+    [path1 addLineToPoint:CGPointMake(538.2213752412169, 332.1902728152941)];
+    [path1 addLineToPoint:CGPointMake(540.5431511220083, 332.413581844774)];
+    [path1 addLineToPoint:CGPointMake(540.5490951094906, 335.5382079644401)];
+    [path1 addLineToPoint:CGPointMake(540.5490725877183, 335.5382195806076)];
+    [path1 addLineToPoint:CGPointMake(540.2847076854124, 335.5455774014496)];
+    [path1 addLineToPoint:CGPointMake(540.400733400935, 339.7143561210604)];
+    [path1 addLineToPoint:CGPointMake(538.304094602082, 352.532259934987)];
+    [path1 addLineToPoint:CGPointMake(536.4839471107854, 352.3747340803717)];
+    [path1 addLineToPoint:CGPointMake(534.4103242346051, 376.3370653418847)];
+    [path1 addLineToPoint:CGPointMake(532.08269466801, 390.5671678860072)];
+    [path1 addLineToPoint:CGPointMake(531.3767599924134, 390.5589736627654)];
+    [path1 addLineToPoint:CGPointMake(531.3226810528386, 395.2135618744243)];
+    [path1 addLineToPoint:CGPointMake(531.3226806383684, 395.213560010806)];
+    [path1 addLineToPoint:CGPointMake(530.5277369387828, 400.0734968032313)];
+    [path1 addLineToPoint:CGPointMake(531.2648311175388, 400.1940638802182)];
+    [path1 addLineToPoint:CGPointMake(531.0971728827068, 414.6231079672491)];
+    [path1 addLineToPoint:CGPointMake(531.0971735298806, 414.6231083914153)];
+    [path1 addLineToPoint:CGPointMake(529.0223531279906, 438.5992779974396)];
+    [path1 addLineToPoint:CGPointMake(530.8168344491056, 438.7545666243153)];
+    [path1 addLineToPoint:CGPointMake(530.7986791012288, 440.3145443645926)];
+    [path1 addLineToPoint:CGPointMake(529.3056863369346, 440.389267719632)];
+    [path1 addLineToPoint:CGPointMake(530.5166544297606, 464.588531902876)];
+    [path1 addLineToPoint:CGPointMake(530.5086629830465, 465.2763061057693)];
+    [path1 addLineToPoint:CGPointMake(529.2599543707523, 465.40573629755)];
+    [path1 addLineToPoint:CGPointMake(530.3814502442603, 476.2255574393188)];
+    [path1 addLineToPoint:CGPointMake(530.3814500583437, 476.225555191424)];
+    [path1 addLineToPoint:CGPointMake(530.3005015933313, 483.1928103551022)];
+    [path1 addLineToPoint:CGPointMake(527.8635975051948, 483.8027439991368)];
+    [path1 addLineToPoint:CGPointMake(532.3814630535373, 501.8537919533474)];
+    [path1 addLineToPoint:CGPointMake(532.3814648151263, 501.8537905289799)];
+    [path1 addLineToPoint:CGPointMake(532.6860631971596, 507.940702942514)];
+    [path1 addLineToPoint:CGPointMake(528.3736515593538, 523.3324118485659)];
+    [path1 addLineToPoint:CGPointMake(535.470280591173, 525.3207229272685)];
+    [path1 addLineToPoint:CGPointMake(535.470263184915, 525.320741061855)];
+    [path1 addLineToPoint:CGPointMake(535.8961042629181, 529.4291148933168)];
+    [path1 addLineToPoint:CGPointMake(539.1974497501886, 529.0869239002784)];
+    [path1 addLineToPoint:CGPointMake(541.0092375056303, 536.3259046593075)];
+    [path1 addLineToPoint:CGPointMake(558.830206058348, 531.8656240115217)];
+    [path1 addLineToPoint:CGPointMake(576.5196412857953, 536.8218029861007)];
+    [path1 addLineToPoint:CGPointMake(578.2640696672908, 530.5956338374954)];
+    [path1 addLineToPoint:CGPointMake(580.4229453721656, 530.9916302933049)];
+    [path1 addLineToPoint:CGPointMake(581.2939078414248, 526.2433514901967)];
+    [path1 addLineToPoint:CGPointMake(581.2938857256669, 526.2433529547152)];
+    [path1 addLineToPoint:CGPointMake(589.5131340965369, 524.1862170398242)];
+    [path1 addLineToPoint:CGPointMake(585.0528574893568, 506.3652646312719)];
+    [path1 addLineToPoint:CGPointMake(586.5547026701971, 501.0049175803932)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(551.1573612550987, 481.0761989090267)];
+    [path2 addLineToPoint:CGPointMake(556.0032487009861, 511.3746837575115)];
+    [path2 addLineToPoint:CGPointMake(559.9515255320906, 536.0609372210276)];
+    [path2 addLineToPoint:CGPointMake(609.3240324591228, 528.1643835588185)];
+    [path2 addLineToPoint:CGPointMake(605.3757556280183, 503.4781300953024)];
+    [path2 addLineToPoint:CGPointMake(600.5298681821309, 473.1796452468175)];
+    [path2 addLineToPoint:CGPointMake(596.5815913510264, 448.4933917833014)];
+    [path2 addLineToPoint:CGPointMake(547.2090844239942, 456.3899454455105)];
+    [path2 addLineToPoint:CGPointMake(551.1573612550987, 481.0761989090267)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
+}
+
+- (void)testUnionPaths5
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(548.0606695021762, 270.2678459523191)];
+    [path1 addLineToPoint:CGPointMake(546.6636356420688, 270.15395759191)];
+    [path1 addLineToPoint:CGPointMake(546.149475906873, 276.460998601125)];
+    [path1 addLineToPoint:CGPointMake(545.8454593673839, 277.4461671103816)];
+    [path1 addLineToPoint:CGPointMake(543.5082986132772, 277.2213752412169)];
+    [path1 addLineToPoint:CGPointMake(542.7849887483235, 284.7417312371214)];
+    [path1 addLineToPoint:CGPointMake(542.7849731422747, 284.7417285498717)];
+    [path1 addLineToPoint:CGPointMake(540.4524971109955, 284.746164750551)];
+    [path1 addLineToPoint:CGPointMake(540.4822257978358, 300.3769836672548)];
+    [path1 addLineToPoint:CGPointMake(540.482238083743, 300.376975957792)];
+    [path1 addLineToPoint:CGPointMake(538.4025530301129, 300.5625663114799)];
+    [path1 addLineToPoint:CGPointMake(539.7794026362358, 315.991242910503)];
+    [path1 addLineToPoint:CGPointMake(538.2213752412169, 332.1902728152941)];
+    [path1 addLineToPoint:CGPointMake(540.5431511220083, 332.413581844774)];
+    [path1 addLineToPoint:CGPointMake(540.55524247373, 338.7697448622874)];
+    [path1 addLineToPoint:CGPointMake(538.304094602082, 352.532259934987)];
+    [path1 addLineToPoint:CGPointMake(536.4839471107854, 352.3747340803717)];
+    [path1 addLineToPoint:CGPointMake(534.4103242346051, 376.3370653418847)];
+    [path1 addLineToPoint:CGPointMake(532.08269466801, 390.5671678860072)];
+    [path1 addLineToPoint:CGPointMake(531.3767599924134, 390.5589736627654)];
+    [path1 addLineToPoint:CGPointMake(531.3226810528386, 395.2135618744243)];
+    [path1 addLineToPoint:CGPointMake(531.3226806383684, 395.213560010806)];
+    [path1 addLineToPoint:CGPointMake(530.5277369387828, 400.0734968032313)];
+    [path1 addLineToPoint:CGPointMake(531.2648311175388, 400.1940638802182)];
+    [path1 addLineToPoint:CGPointMake(531.0971728827068, 414.6231079672491)];
+    [path1 addLineToPoint:CGPointMake(531.0971735298806, 414.6231083914153)];
+    [path1 addLineToPoint:CGPointMake(529.0223531279906, 438.5992779974396)];
+    [path1 addLineToPoint:CGPointMake(530.8168344491056, 438.7545666243153)];
+    [path1 addLineToPoint:CGPointMake(530.7986791012288, 440.3145443645926)];
+    [path1 addLineToPoint:CGPointMake(529.3056863369346, 440.389267719632)];
+    [path1 addLineToPoint:CGPointMake(530.5166544297606, 464.588531902876)];
+    [path1 addLineToPoint:CGPointMake(530.5086629830465, 465.2763061057693)];
+    [path1 addLineToPoint:CGPointMake(529.2599543707523, 465.40573629755)];
+    [path1 addLineToPoint:CGPointMake(530.3814502442603, 476.2255574393188)];
+    [path1 addLineToPoint:CGPointMake(530.3814500583437, 476.225555191424)];
+    [path1 addLineToPoint:CGPointMake(530.3005015933313, 483.1928103551022)];
+    [path1 addLineToPoint:CGPointMake(527.8635975051948, 483.8027439991368)];
+    [path1 addLineToPoint:CGPointMake(532.3814630535373, 501.8537919533474)];
+    [path1 addLineToPoint:CGPointMake(532.3814648151263, 501.8537905289799)];
+    [path1 addLineToPoint:CGPointMake(532.6860631971596, 507.940702942514)];
+    [path1 addLineToPoint:CGPointMake(528.3736515593538, 523.3324118485659)];
+    [path1 addLineToPoint:CGPointMake(535.470280591173, 525.3207229272685)];
+    [path1 addLineToPoint:CGPointMake(535.470263184915, 525.320741061855)];
+    [path1 addLineToPoint:CGPointMake(535.8961042629181, 529.4291148933168)];
+    [path1 addLineToPoint:CGPointMake(539.1974497501886, 529.0869239002784)];
+    [path1 addLineToPoint:CGPointMake(541.0092375056303, 536.3259046593075)];
+    [path1 addLineToPoint:CGPointMake(558.830206058348, 531.8656240115217)];
+    [path1 addLineToPoint:CGPointMake(576.5196412857953, 536.8218029861007)];
+    [path1 addLineToPoint:CGPointMake(578.2640696672908, 530.5956338374954)];
+    [path1 addLineToPoint:CGPointMake(580.4229453721656, 530.9916302933049)];
+    [path1 addLineToPoint:CGPointMake(581.2939078414248, 526.2433514901967)];
+    [path1 addLineToPoint:CGPointMake(581.2938857256669, 526.2433529547152)];
+    [path1 addLineToPoint:CGPointMake(589.5131340965369, 524.1862170398242)];
+    [path1 addLineToPoint:CGPointMake(585.0528574893568, 506.3652646312719)];
+    [path1 addLineToPoint:CGPointMake(591.1613051506029, 484.5631509219969)];
+    [path1 addLineToPoint:CGPointMake(589.0769704830165, 483.9791686266416)];
+    [path1 addLineToPoint:CGPointMake(591.4062260347368, 471.3989823792022)];
+    [path1 addLineToPoint:CGPointMake(593.7735073405944, 471.5968633375218)];
+    [path1 addLineToPoint:CGPointMake(595.7521944070655, 447.9264218801845)];
+    [path1 addLineToPoint:CGPointMake(596.0214079014386, 446.4724092508916)];
+    [path1 addLineToPoint:CGPointMake(598.6817287764064, 446.3777826175018)];
+    [path1 addLineToPoint:CGPointMake(598.2557548774608, 434.4046929783055)];
+    [path1 addLineToPoint:CGPointMake(598.255757752456, 434.4046973894274)];
+    [path1 addLineToPoint:CGPointMake(600.0765864530991, 424.5704110987463)];
+    [path1 addLineToPoint:CGPointMake(597.8914788349319, 424.1658360693491)];
+    [path1 addLineToPoint:CGPointMake(597.845785036679, 422.8814384662383)];
+    [path1 addLineToPoint:CGPointMake(598.4195530453338, 416.0176084236699)];
+    [path1 addLineToPoint:CGPointMake(598.9005854980256, 415.9746631257495)];
+    [path1 addLineToPoint:CGPointMake(598.6540658843851, 413.2122180647474)];
+    [path1 addLineToPoint:CGPointMake(598.6540643192939, 413.2122202066951)];
+    [path1 addLineToPoint:CGPointMake(599.8043308699894, 399.4519255598385)];
+    [path1 addLineToPoint:CGPointMake(597.4082024416637, 399.2516256060214)];
+    [path1 addLineToPoint:CGPointMake(596.7378154843714, 391.7391337328909)];
+    [path1 addLineToPoint:CGPointMake(596.7378163445783, 391.7391349101218)];
+    [path1 addLineToPoint:CGPointMake(595.8726960374154, 367.4227084530307)];
+    [path1 addLineToPoint:CGPointMake(594.5719601426955, 367.4689855258055)];
+    [path1 addLineToPoint:CGPointMake(591.7315838278868, 335.6403793918167)];
+    [path1 addLineToPoint:CGPointMake(594.340144997684, 319.6927788984932)];
+    [path1 addLineToPoint:CGPointMake(594.3401508858758, 319.6927659222111)];
+    [path1 addLineToPoint:CGPointMake(594.8105322706595, 319.7604657759737)];
+    [path1 addLineToPoint:CGPointMake(596.198510838496, 310.1167332639626)];
+    [path1 addLineToPoint:CGPointMake(596.1984856617421, 310.1167349879589)];
+    [path1 addLineToPoint:CGPointMake(596.6099435393584, 310.1689451693507)];
+    [path1 addLineToPoint:CGPointMake(599.0729543075099, 290.758455563808)];
+    [path1 addLineToPoint:CGPointMake(599.5399161687859, 287.9036558711749)];
+    [path1 addLineToPoint:CGPointMake(599.5399170553948, 287.9036565639494)];
+    [path1 addLineToPoint:CGPointMake(604.7594798171671, 287.3125082593189)];
+    [path1 addLineToPoint:CGPointMake(602.4348079328421, 266.7867439025244)];
+    [path1 addLineToPoint:CGPointMake(603.2623056028136, 261.037195002068)];
+    [path1 addLineToPoint:CGPointMake(603.2369377416157, 261.0335439211602)];
+    [path1 addLineToPoint:CGPointMake(608.0044915928995, 245.58415456029)];
+    [path1 addLineToPoint:CGPointMake(604.9257197436657, 244.6340652475577)];
+    [path1 addLineToPoint:CGPointMake(605.0530360784416, 243.6306408762261)];
+    [path1 addLineToPoint:CGPointMake(599.7358391613545, 242.9559379949846)];
+    [path1 addLineToPoint:CGPointMake(598.7720320688427, 234.4461478884606)];
+    [path1 addLineToPoint:CGPointMake(579.123046312684, 236.6715190828699)];
+    [path1 addLineToPoint:CGPointMake(579.1230465124466, 236.6715252227085)];
+    [path1 addLineToPoint:CGPointMake(560.2276610537965, 230.8405300521222)];
+    [path1 addLineToPoint:CGPointMake(558.1185556991254, 237.6751024507487)];
+    [path1 addLineToPoint:CGPointMake(555.4507707463559, 237.3365743111688)];
+    [path1 addLineToPoint:CGPointMake(555.1912323490045, 239.3819439170066)];
+    [path1 addLineToPoint:CGPointMake(549.0896543819672, 240.0729895761789)];
+    [path1 addLineToPoint:CGPointMake(551.0116322985548, 257.0431547340426)];
+    [path1 addLineToPoint:CGPointMake(551.011636516994, 257.0431482456252)];
+    [path1 addLineToPoint:CGPointMake(549.6201483204835, 265.2142588238856)];
+    [path1 addLineToPoint:CGPointMake(548.0606438198089, 270.2678450297012)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(541.321122179749, 336.3647211534527)];
+    [path2 addLineToPoint:CGPointMake(540.973394907022, 359.4640718028032)];
+    [path2 addLineToPoint:CGPointMake(540.5970987444573, 384.4612396663441)];
+    [path2 addLineToPoint:CGPointMake(590.5914344715391, 385.2138319914735)];
+    [path2 addLineToPoint:CGPointMake(590.9677306341038, 360.2166641279326)];
+    [path2 addLineToPoint:CGPointMake(591.3154579068307, 337.1173134785821)];
+    [path2 addLineToPoint:CGPointMake(591.6917540693954, 312.1201456150413)];
+    [path2 addLineToPoint:CGPointMake(541.6974183423137, 311.3675532899119)];
+    [path2 addLineToPoint:CGPointMake(541.321122179749, 336.3647211534527)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
+}
+
+- (void)testUnionPaths6
 {
     UIBezierPath *path1 = [UIBezierPath bezierPath];
     [path1 moveToPoint:CGPointMake(620.8655482851358, 335.9684147785148)];
@@ -396,6 +728,73 @@
     NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
 
     XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
+}
+
+- (void)testUnionPaths7
+{
+    UIBezierPath *path1 = [UIBezierPath bezierPath];
+    [path1 moveToPoint:CGPointMake(600.4383961256497, 407.3983834412122)];
+    [path1 addLineToPoint:CGPointMake(599.6018663984008, 405.0719462890968)];
+    [path1 addLineToPoint:CGPointMake(593.7861948066816, 407.1631191221845)];
+    [path1 addLineToPoint:CGPointMake(592.7698518857133, 404.9390888035055)];
+    [path1 addLineToPoint:CGPointMake(582.4851658523235, 409.6390629037863)];
+    [path1 addLineToPoint:CGPointMake(582.1848615743246, 408.9405879264772)];
+    [path1 addLineToPoint:CGPointMake(577.92455473932, 410.7722643242638)];
+    [path1 addLineToPoint:CGPointMake(577.90825651048, 410.7398423978149)];
+    [path1 addLineToPoint:CGPointMake(577.362363036066, 411.0139717008453)];
+    [path1 addLineToPoint:CGPointMake(571.8371523434469, 413.3894822205745)];
+    [path1 addLineToPoint:CGPointMake(571.8371401490955, 413.3895094802881)];
+    [path1 addLineToPoint:CGPointMake(568.5874713256284, 409.0852787756284)];
+    [path1 addLineToPoint:CGPointMake(556.505307402506, 418.2072413550235)];
+    [path1 addLineToPoint:CGPointMake(556.5053111309837, 418.2072492318206)];
+    [path1 addLineToPoint:CGPointMake(550.1740127599218, 419.7649406765397)];
+    [path1 addLineToPoint:CGPointMake(550.2039211397246, 419.8865044669607)];
+    [path1 addLineToPoint:CGPointMake(539.9154774678462, 421.8143488245427)];
+    [path1 addLineToPoint:CGPointMake(540.8344656009308, 426.7187818396026)];
+    [path1 addLineToPoint:CGPointMake(530.8573359733522, 431.0083452127848)];
+    [path1 addLineToPoint:CGPointMake(531.0792271031848, 431.52444308804)];
+    [path1 addLineToPoint:CGPointMake(526.927972248705, 433.123840927393)];
+    [path1 addLineToPoint:CGPointMake(529.1408002562009, 438.8672820768995)];
+    [path1 addLineToPoint:CGPointMake(524.2286198400815, 442.575950305231)];
+    [path1 addLineToPoint:CGPointMake(537.1776704322293, 459.7271445292165)];
+    [path1 addLineToPoint:CGPointMake(537.177669614459, 459.7271437692976)];
+    [path1 addLineToPoint:CGPointMake(544.9039007418461, 479.7807374680918)];
+    [path1 addLineToPoint:CGPointMake(550.6473418913527, 477.567909460596)];
+    [path1 addLineToPoint:CGPointMake(554.3560101196841, 482.4800898767154)];
+    [path1 addLineToPoint:CGPointMake(570.0302176039944, 470.6461555712947)];
+    [path1 addLineToPoint:CGPointMake(570.0302144286278, 470.6461527167251)];
+    [path1 addLineToPoint:CGPointMake(574.701898727402, 468.3001903251144)];
+    [path1 addLineToPoint:CGPointMake(579.8563225744359, 466.3142988039456)];
+    [path1 addLineToPoint:CGPointMake(582.6664929154342, 466.464409843924)];
+    [path1 addCurveToPoint:CGPointMake(598.7973503134953, 461.651305825648) controlPoint1:CGPointMake(588.6747306683986, 466.7853478376288) controlPoint2:CGPointMake(594.3006072562862, 464.9573004528888)];
+    [path1 addLineToPoint:CGPointMake(602.7484629618413, 460.9109624547542)];
+    [path1 addLineToPoint:CGPointMake(602.3024776399483, 458.5308390797298)];
+    [path1 addCurveToPoint:CGPointMake(602.4222767059863, 458.4013225750541) controlPoint1:CGPointMake(602.3425596337614, 458.4878098450634) controlPoint2:CGPointMake(602.3824929470718, 458.4446374150812)];
+    [path1 addLineToPoint:CGPointMake(614.7843612635157, 455.3598762179916)];
+    [path1 addLineToPoint:CGPointMake(614.1937218297007, 452.9591989221919)];
+    [path1 addLineToPoint:CGPointMake(616.5201557616844, 452.1226793866821)];
+    [path1 addLineToPoint:CGPointMake(608.5010354006486, 429.8210457118649)];
+    [path1 addLineToPoint:CGPointMake(602.8390632297104, 406.8077407872656)];
+    [path1 addLineToPoint:CGPointMake(600.4384147096662, 407.3983731413718)];
+    [path1 closePath];
+
+    UIBezierPath *path2 = [UIBezierPath bezierPath];
+    [path2 moveToPoint:CGPointMake(566.3714093416369, 417.0628529001687)];
+    [path2 addLineToPoint:CGPointMake(563.5668439119494, 417.8964405466531)];
+    [path2 addLineToPoint:CGPointMake(539.6029634136805, 425.01911079486)];
+    [path2 addLineToPoint:CGPointMake(553.8483039100943, 472.9468717913975)];
+    [path2 addLineToPoint:CGPointMake(577.8121844083631, 465.8242015431907)];
+    [path2 addLineToPoint:CGPointMake(580.6167498380506, 464.9906138967063)];
+    [path2 addLineToPoint:CGPointMake(604.5806303363195, 457.8679436484994)];
+    [path2 addLineToPoint:CGPointMake(590.3352898399057, 409.9401826519618)];
+    [path2 addLineToPoint:CGPointMake(566.3714093416369, 417.0628529001687)];
+    [path2 closePath];
+
+    NSArray<UIBezierPath *> *finalShapes = [path1 unionWithPath:path2];
+
+    XCTAssertEqual([finalShapes count], 1);
+    XCTAssertTrue(finalShapes[0].isClosed);
 }
 
 @end

--- a/ClippingExampleApp/UIBezierPath+SamplePaths.m
+++ b/ClippingExampleApp/UIBezierPath+SamplePaths.m
@@ -14,7 +14,7 @@
     UIBezierPath *shapePath1 = [UIBezierPath bezierPath];
     [shapePath1 moveToPoint:CGPointMake(218.500000, 376.000000)];
     [shapePath1 addCurveToPoint:CGPointMake(227.000000, 362.000000) controlPoint1:CGPointMake(218.100235, 369.321564) controlPoint2:CGPointMake(222.816589, 365.945923)];
-    //    [complexShape addCurveToPoint:CGPointMake(213.000000,372.000000) controlPoint1:CGPointMake(237.447144,352.833008) controlPoint2:CGPointMake(255.082840,326.966705)];
+    //    [shapePath1 addCurveToPoint:CGPointMake(213.000000,372.000000) controlPoint1:CGPointMake(237.447144,352.833008) controlPoint2:CGPointMake(255.082840,326.966705)];
     [shapePath1 addCurveToPoint:CGPointMake(243.000000, 316.000000) controlPoint1:CGPointMake(232.801880, 363.107697) controlPoint2:CGPointMake(248.582321, 338.033752)];
     [shapePath1 addCurveToPoint:CGPointMake(172.000000, 218.000000) controlPoint1:CGPointMake(215.326599, 286.866608) controlPoint2:CGPointMake(182.880371, 258.374298)];
     [shapePath1 addCurveToPoint:CGPointMake(242.000000, 111.000000) controlPoint1:CGPointMake(149.812820, 168.222122) controlPoint2:CGPointMake(195.466583, 119.790573)];


### PR DESCRIPTION
Lots of fixed tests and additional tests. When calculating intersections, the direction of the intersection (path moving into other path, or moving out of other path, or tangent to path) is now tracked. a path moves into the other path if it's tangent is to the right, out of the path if it moves left, and tangent otherwise.

also made some changes to the ClippingExampleApp. copy any two paths you're debugging into the `debug1` and `debug2` methods, and then run the app. can hold down a finger or click to zoom, and can swap between the different algorithms.

there were also quite a few tests that i'd never really defined correct behavior for. I've moved these failing tests to `MMClippingBezierTodoTests` to fix later. this way, any changes we make we can easily see new failed tests that are not in `MMClippingBezierTodoTests` and make sure no new failed tests slip through.